### PR TITLE
toolchain.eclass: enable pie and ssp for gcc >= 6 for #615370

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -153,7 +153,7 @@ if [[ ${PN} != "kgcc64" && ${PN} != gcc-* ]] ; then
 	tc_version_is_at_least 4.8 && IUSE+=" graphite" IUSE_DEF+=( sanitize )
 	tc_version_is_at_least 4.9 && IUSE+=" cilk +vtv"
 	tc_version_is_at_least 5.0 && IUSE+=" jit mpx"
-	tc_version_is_at_least 6.0 && IUSE+=" pie ssp +pch"
+	tc_version_is_at_least 6.0 && IUSE+=" +pie +ssp +pch"
 fi
 
 IUSE+=" ${IUSE_DEF[*]/#/+}"


### PR DESCRIPTION
Take over upstream commit

  commit 4000cdde4281ffef9b61da83f16a30547131259a
  Author: William Hubbs <williamh@gentoo.org>
  Date:   Sat May 6 10:31:31 2017 -0500

    toolchain.eclass: enable pie and ssp for gcc >= 6 for #615370