### PR TITLE
sys-apps/iucode_tool: link against argp-standalone on musl systems

### DIFF
--- a/sys-apps/iucode_tool/files/iucode_tool-2.2-argp.patch
+++ b/sys-apps/iucode_tool/files/iucode_tool-2.2-argp.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.am b/Makefile.am
+index 415a241..06e6872 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -2,6 +2,8 @@
+ ## Toplevel Makefile.am for iucode_tool
+ ##
+ 
++AM_LDFLAGS = -largp
++
+ sbin_PROGRAMS	 = iucode_tool
+ man_MANS	 = iucode_tool.8
+ 

--- a/sys-apps/iucode_tool/iucode_tool-2.2.ebuild
+++ b/sys-apps/iucode_tool/iucode_tool-2.2.ebuild
@@ -3,6 +3,8 @@
 
 EAPI="6"
 
+inherit autotools eutils
+
 DESCRIPTION="tool to manipulate Intel X86 and X86-64 processor microcode update collections"
 HOMEPAGE="https://gitlab.com/iucode-tool/"
 SRC_URI="https://gitlab.com/iucode-tool/releases/raw/master/${PN/_/-}_${PV}.tar.xz"
@@ -12,6 +14,16 @@ SLOT="0"
 KEYWORDS="-* ~amd64 ~x86"
 IUSE=""
 
-PATCHES=( "${FILESDIR}"/${P}-limits.patch )
+DEPEND="elibc_musl? ( sys-libs/argp-standalone )"
+RDEPEND=${DEPEND}
 
 S="${WORKDIR}/${PN/_/-}-${PV}"
+
+src_prepare() {
+	eapply "${FILESDIR}/${P}-limits.patch"
+	use elibc_musl && eapply "${FILESDIR}/${P}-argp.patch"
+
+	eapply_user
+
+	eautoreconf
+}


### PR DESCRIPTION
iucode_tool makes use of the argp header, which is not part of musl,
causing the build to fail on such systems. To fix that, add a dependency
on argp-standalone on musl-based systems and explicitly link against the
argp library.