### PR TITLE
dev-lang/rust: attempt to make the build system to honor MAKEOPTS  

### DIFF
--- a/dev-lang/rust/rust-1.21.0.ebuild
+++ b/dev-lang/rust/rust-1.21.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 LLVM_MAX_SLOT=4
 PYTHON_COMPAT=( python2_7 )
 
-inherit python-any-r1 versionator toolchain-funcs llvm
+inherit multiprocessing python-any-r1 versionator toolchain-funcs llvm
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -173,11 +173,11 @@ src_configure() {
 }
 
 src_compile() {
-	./x.py build || die
+	./x.py build -j$(makeopts_jobs) || die
 }
 
 src_install() {
-	env DESTDIR="${D}" ./x.py install || die
+	env DESTDIR="${D}" ./x.py install -j$(makeopts_jobs) || die
 
 	rm "${D}/usr/$(get_libdir)/rustlib/components" || die
 	rm "${D}/usr/$(get_libdir)/rustlib/install.log" || die

--- a/dev-lang/rust/rust-1.23.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.23.0-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 LLVM_MAX_SLOT=4
 PYTHON_COMPAT=( python2_7 )
 
-inherit python-any-r1 versionator toolchain-funcs llvm
+inherit multiprocessing python-any-r1 versionator toolchain-funcs llvm
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -189,7 +189,7 @@ src_configure() {
 }
 
 src_compile() {
-	./x.py build || die
+	./x.py build -j$(makeopts_jobs) || die
 }
 
 src_install() {

--- a/dev-lang/rust/rust-1.23.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.23.0-r1.ebuild
@@ -193,7 +193,7 @@ src_compile() {
 }
 
 src_install() {
-	env DESTDIR="${D}" ./x.py install || die
+	env DESTDIR="${D}" ./x.py install -j$(makeopts_jobs) || die
 
 	rm "${D}/usr/$(get_libdir)/rustlib/components" || die
 	rm "${D}/usr/$(get_libdir)/rustlib/install.log" || die

--- a/dev-lang/rust/rust-1.23.0.ebuild
+++ b/dev-lang/rust/rust-1.23.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 LLVM_MAX_SLOT=4
 PYTHON_COMPAT=( python2_7 )
 
-inherit python-any-r1 versionator toolchain-funcs llvm
+inherit multiprocessing python-any-r1 versionator toolchain-funcs llvm
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -178,11 +178,11 @@ src_configure() {
 }
 
 src_compile() {
-	./x.py build || die
+	./x.py build -j$(makeopts_jobs) || die
 }
 
 src_install() {
-	env DESTDIR="${D}" ./x.py install || die
+	env DESTDIR="${D}" ./x.py install -j$(makeopts_jobs) || die
 
 	rm "${D}/usr/$(get_libdir)/rustlib/components" || die
 	rm "${D}/usr/$(get_libdir)/rustlib/install.log" || die

--- a/dev-util/cargo/cargo-0.22.0-r1.ebuild
+++ b/dev-util/cargo/cargo-0.22.0-r1.ebuild
@@ -121,7 +121,7 @@ wincolor-0.1.4
 ws2_32-sys-0.2.1
 "
 
-inherit bash-completion-r1 cargo versionator
+inherit multiprocessing bash-completion-r1 cargo versionator
 
 case "${CHOST}" in
 	armv7a-hardfloat-*)
@@ -208,7 +208,7 @@ src_configure() {
 src_compile() {
 	export CARGO_HOME="${ECARGO_HOME}"
 	local cargo="${WORKDIR}/cargo-${CARGO_SNAPSHOT_VERSION}-${CARGOHOST}/cargo/bin/cargo"
-	${cargo} build --release || die
+	${cargo} build --release -j$(makeopts_jobs) || die
 
 	# Building HTML documentation
 	use doc && ${cargo} doc

--- a/dev-util/cargo/cargo-0.23.0.ebuild
+++ b/dev-util/cargo/cargo-0.23.0.ebuild
@@ -128,7 +128,7 @@ wincolor-0.1.4
 ws2_32-sys-0.2.1
 "
 
-inherit bash-completion-r1 cargo versionator
+inherit multiprocessing bash-completion-r1 cargo versionator
 
 case "${CHOST}" in
 	armv7a-hardfloat-*)
@@ -215,7 +215,7 @@ src_configure() {
 src_compile() {
 	export CARGO_HOME="${ECARGO_HOME}"
 	local cargo="${WORKDIR}/cargo-${CARGO_SNAPSHOT_VERSION}-${CARGOHOST}/cargo/bin/cargo"
-	${cargo} build --release || die
+	${cargo} build --release -j$(makeopts_jobs) || die
 
 	# Building HTML documentation
 	use doc && ${cargo} doc

--- a/dev-util/cargo/cargo-0.24.0.ebuild
+++ b/dev-util/cargo/cargo-0.24.0.ebuild
@@ -132,7 +132,7 @@ wincolor-0.1.4
 ws2_32-sys-0.2.1
 "
 
-inherit bash-completion-r1 cargo versionator
+inherit multiprocessing bash-completion-r1 cargo versionator
 
 case "${CHOST}" in
 	armv7a-hardfloat-*)
@@ -217,7 +217,7 @@ src_configure() {
 src_compile() {
 	export CARGO_HOME="${ECARGO_HOME}"
 	local cargo="${WORKDIR}/cargo-${CARGO_SNAPSHOT_VERSION}-${CARGOHOST}/cargo/bin/cargo"
-	${cargo} build --release || die
+	${cargo} build --release -j$(makeopts_jobs) || die
 
 	# Building HTML documentation
 	use doc && ${cargo} doc


### PR DESCRIPTION
by default, dev-lang/rust does use one job per thread, which can be a problem if there is not enough memory per job on the build system. It was fixed for src_compile recently in the main tree, however there are some subtle differences in the structure of the ebuilds and I'm not certain if this fix actually works as intended for the musl ebuild provided here.  

I will test it, but it might take some time. If someone with more experience thinks the fix will be working, or tests this on his own, I'd be fine with it. 