### PR TITLE
net-analyzer/wireshark: patch same as upstream

### DIFF
--- a/net-analyzer/wireshark/files/wireshark-includes-fix-musl.patch
+++ b/net-analyzer/wireshark/files/wireshark-includes-fix-musl.patch
@@ -6,8 +6,8 @@ index 44cc24e1db..1310e37e61 100644
  	#include <unistd.h>
  #endif
  
-+#ifdef HAVE_SYS_TYPES_H
-+	#include <sys/types.h>
++#ifdef HAVE_SYS_TIME_H
++	#include <sys/time.h>
 +#endif
 +
  #ifdef HAVE_ARPA_INET_H


### PR DESCRIPTION
Make the wireshark musl patch the same as what is in the upstream project.