### PR TITLE
dev-lang/rust: http-parser-2.8 breaks cargo from the stage0

### DIFF
--- a/dev-lang/rust/rust-1.23.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.23.0-r1.ebuild
@@ -80,7 +80,7 @@ RDEPEND=">=app-eselect/eselect-rust-0.3_pre20150425
 				<dev-libs/libressl-2.7.0:=
 			)
 			!libressl? ( dev-libs/openssl:0= )
-			net-libs/http-parser:=
+			net-libs/http-parser:0/2.6.2
 			net-libs/libssh2:=
 			net-misc/curl:=[ssl]
 			sys-libs/zlib:=

--- a/dev-lang/rust/rust-1.23.0.ebuild
+++ b/dev-lang/rust/rust-1.23.0.ebuild
@@ -74,6 +74,7 @@ IUSE="debug doc jemalloc system-llvm"
 RDEPEND=">=app-eselect/eselect-rust-0.3_pre20150425
 		jemalloc? ( dev-libs/jemalloc )
 		system-llvm? ( sys-devel/llvm:4 )
+	net-libs/http-parser:0/2.6.2
 "
 DEPEND="${RDEPEND}
 	${PYTHON_DEPS}


### PR DESCRIPTION
It can't be build against http-parser-2.8:
```
Error loading shared library libhttp_parser.so.2.6.2: No such file or directory (needed by /var/tmp/portage/dev-lang/rust-1.23.0/work/stage0/bin/cargo)
Error relocating /var/tmp/portage/dev-lang/rust-1.23.0/work/stage0/bin/cargo: http_should_keep_alive: symbol not found
Error relocating /var/tmp/portage/dev-lang/rust-1.23.0/work/stage0/bin/cargo: http_parser_init: symbol not found
Error relocating /var/tmp/portage/dev-lang/rust-1.23.0/work/stage0/bin/cargo: http_errno_description: symbol not found
Error relocating /var/tmp/portage/dev-lang/rust-1.23.0/work/stage0/bin/cargo: http_parser_parse_url: symbol not found
Error relocating /var/tmp/portage/dev-lang/rust-1.23.0/work/stage0/bin/cargo: http_parser_execute: symbol not found
```