### PR TITLE
Fix compiling radv: add missing #include <pthread.h>

### DIFF
--- a/media-libs/mesa/files/mesa-18-musl-amdgpu-include-pthread.patch
+++ b/media-libs/mesa/files/mesa-18-musl-amdgpu-include-pthread.patch
@@ -1,0 +1,11 @@
+diff -Naur mesa-18.1.3-orig/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.h mesa-18.1.3/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.h
+--- mesa-18.1.3-orig/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.h	2018-07-08 22:01:10.758633781 +0300
++++ mesa-18.1.3/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.h	2018-07-08 22:01:30.097631709 +0300
+@@ -32,6 +32,7 @@
+ #include "ac_gpu_info.h"
+ #include "addrlib/addrinterface.h"
+ #include <amdgpu.h>
++#include <pthread.h>
+ #include "util/list.h"
+ 
+ struct radv_amdgpu_winsys {

--- a/media-libs/mesa/mesa-18.0.5.ebuild
+++ b/media-libs/mesa/mesa-18.0.5.ebuild
@@ -274,6 +274,7 @@ src_prepare() {
 	eapply "${FILESDIR}"/${PN}-17-musl-string_h.patch
 	eapply "${FILESDIR}"/${PN}-17-musl-invocation_name.patch
 	eapply "${FILESDIR}"/${PN}-18-musl-pthread.patch
+	eapply "${FILESDIR}"/${PN}-18-musl-amdgpu-include-pthread.patch
 
 	eautoreconf
 

--- a/media-libs/mesa/mesa-18.1.1.ebuild
+++ b/media-libs/mesa/mesa-18.1.1.ebuild
@@ -275,7 +275,7 @@ src_prepare() {
 	eapply "${FILESDIR}"/${PN}-17-musl-invocation_name.patch
 	eapply "${FILESDIR}"/${PN}-18-musl-pthread.patch
 	eapply "${FILESDIR}"/${PN}-18-intel-missing-time_t.patch
-
+	eapply "${FILESDIR}"/${PN}-18-musl-amdgpu-include-pthread.patch
 	eautoreconf
 
 	eapply_user


### PR DESCRIPTION
Add a patch to include pthread.h in radv_amdgpu_winsys.h to 18.x ebuilds.