### PR TITLE
sys-libs/compiler-rt-sanitizers: fix double sysinfo include

### DIFF
--- a/sys-libs/compiler-rt-sanitizers/compiler-rt-sanitizers-6.0.1.ebuild
+++ b/sys-libs/compiler-rt-sanitizers/compiler-rt-sanitizers-6.0.1.ebuild
@@ -40,7 +40,10 @@ DEPEND="
 
 S=${WORKDIR}/${MY_P}
 
-PATCHES=( "${FILESDIR}"/${PN}-6.0.1-musl-patches.patch )
+PATCHES=(
+	"${FILESDIR}/${PN}-6.0.1-musl-patches.patch"
+	"${FILESDIR}/${PN}-6.0.1-musl-double-sysinfo-include.patch"
+)
 
 # least intrusive of all
 CMAKE_BUILD_TYPE=RelWithDebInfo

--- a/sys-libs/compiler-rt-sanitizers/files/compiler-rt-sanitizers-6.0.1-musl-double-sysinfo-include.patch
+++ b/sys-libs/compiler-rt-sanitizers/files/compiler-rt-sanitizers-6.0.1-musl-double-sysinfo-include.patch
@@ -1,0 +1,13 @@
+Fixes duplicate definition of struct sysinfo
+
+diff -Naur compiler-rt-6.0.1.src.old/lib/sanitizer_common/sanitizer_platform_limits_posix.cc compiler-rt-6.0.1.src/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+--- compiler-rt-6.0.1.src.old/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
++++ compiler-rt-6.0.1.src/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -63,7 +63,6 @@
+ #include <malloc.h>
+ #include <mntent.h>
+ #include <netinet/ether.h>
+-#include <sys/sysinfo.h>
+ #include <sys/vt.h>
+ #include <linux/cdrom.h>
+ #include <linux/fd.h>


### PR DESCRIPTION
The overlay's sys-libs/compiler-rt-sanitizers-6.0.1 ebuild fails for me due to redefinition of 'sysinfo'. The attached patch fixes this by removing the inclusion of `sys/sysinfo.h` and only keeping the include of `linux/sysinfo.h`.

There might be another way. Please comment.

### Shortened `emerge --info`
ld GNU ld (Gentoo 2.30 p2) 2.30.0
app-shells/bash:          4.3_p48-r1::gentoo
dev-util/cmake:           3.9.6::gentoo
sys-apps/baselayout:      2.4.1-r2::gentoo
sys-apps/sandbox:         2.13::musl
sys-devel/binutils:       2.30-r2::gentoo
sys-devel/gcc:            7.3.0-r3::musl
sys-devel/libtool:        2.4.6-r3::gentoo
sys-devel/make:           4.2.1-r4::gentoo
sys-kernel/linux-headers: 4.17::musl (virtual/os-headers)
sys-libs/musl:            1.1.20::gentoo

### Error report of the compiler

FAILED: lib/sanitizer_common/CMakeFiles/RTSanitizerCommonNoTermination.x86_64.dir/sanitizer_platform_limits_posix.cc.o 
/usr/lib/llvm/6/bin/x86_64-gentoo-linux-musl-clang++ -DHAVE_RPC_XDR_H=1 -I/var/tmp/portage/sys-libs/compiler-rt-sanitizers-6.0.1/work/compiler-rt-6.0.1.src/lib/sanitizer_common/.. -I/usr/include/tirpc  -march=skylake -msgx -O2 -pipe -Wall -std=c++11 -Wno-unused-parameter    -march=skylake -msgx -O2 -pipe -Wall -std=c++11 -Wno-unused-parameter -m64 -fPIC -fno-builtin -fno-exceptions -fomit-frame-pointer -funwind-tables -fno-stack-protector -fno-sanitize=safe-stack -fvisibility=hidden -fno-lto -O3 -gline-tables-only -Wno-gnu -Wno-variadic-macros -Wno-c99-extensions -Wno-non-virtual-dtor -fno-rtti -Wframe-larger-than=570 -Wglobal-constructors -MD -MT lib/sanitizer_common/CMakeFiles/RTSanitizerCommonNoTermination.x86_64.dir/sanitizer_platform_limits_posix.cc.o -MF lib/sanitizer_common/CMakeFiles/RTSanitizerCommonNoTermination.x86_64.dir/sanitizer_platform_limits_posix.cc.o.d -o lib/sanitizer_common/CMakeFiles/RTSanitizerCommonNoTermination.x86_64.dir/sanitizer_platform_limits_posix.cc.o -c /var/tmp/portage/sys-libs/compiler-rt-sanitizers-6.0.1/work/compiler-rt-6.0.1.src/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
In file included from /var/tmp/portage/sys-libs/compiler-rt-sanitizers-6.0.1/work/compiler-rt-6.0.1.src/lib/sanitizer_common/sanitizer_platform_limits_posix.cc:75:
In file included from /usr/include/linux/sysctl.h:26:
In file included from /usr/include/linux/kernel.h:5:
/usr/include/linux/sysinfo.h:8:8: error: redefinition of 'sysinfo'
struct sysinfo {
       ^
/usr/include/sys/sysinfo.h:10:8: note: previous definition is here
struct sysinfo {
       ^
1 error generated.
ninja: build stopped: subcommand failed.
 * ERROR: sys-libs/compiler-rt-sanitizers-6.0.1::musl failed (compile phase):
 *   ninja -v -j2 -l1 failed