### PR TITLE
net-fs/autofs: fix segfault when using automount with --debug flag

### DIFF
--- a/net-fs/autofs/autofs-5.1.4.ebuild
+++ b/net-fs/autofs/autofs-5.1.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -47,6 +47,7 @@ CONFIG_CHECK="~AUTOFS4_FS"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-musl.patch
+	"${FILESDIR}"/${PN}-early-pthread_key_create.patch
 )
 
 src_prepare() {

--- a/net-fs/autofs/files/autofs-early-pthread_key_create.patch
+++ b/net-fs/autofs/files/autofs-early-pthread_key_create.patch
@@ -1,0 +1,42 @@
+Fixes segfault when launching autofs with debugging info
+
+--- autofs-5.1.4/daemon/automount.c	2017-12-19 03:46:44.000000000 +0100
++++ autofs-5.1.4/daemon/automount.c	2018-10-28 12:45:28.388254819 +0100
+@@ -2495,16 +2495,10 @@ int main(int argc, char *argv[])
+ 		macro_free_global_table();
+ 		exit(1);
+ 	}
+-
+-	info(logging, "Starting automounter version %s, master map %s",
+-		version, master_list->name);
+-	info(logging, "using kernel protocol version %d.%02d",
+-		get_kver_major(), get_kver_minor());
+-
+-	status = pthread_key_create(&key_thread_stdenv_vars,
+-				key_thread_stdenv_vars_destroy);
++	
++	status = pthread_key_create(&key_thread_attempt_id, free);
+ 	if (status) {
+-		logerr("%s: failed to create thread data key for std env vars!",
++		logerr("%s: failed to create thread data key for attempt ID!",
+ 		       program);
+ 		master_kill(master_list);
+ 		res = write(start_pipefd[1], pst_stat, sizeof(*pst_stat));
+@@ -2513,10 +2507,15 @@ int main(int argc, char *argv[])
+ 		macro_free_global_table();
+ 		exit(1);
+ 	}
++	info(logging, "Starting automounter version %s, master map %s",
++		version, master_list->name);
++	info(logging, "using kernel protocol version %d.%02d",
++		get_kver_major(), get_kver_minor());
+ 
+-	status = pthread_key_create(&key_thread_attempt_id, free);
++	status = pthread_key_create(&key_thread_stdenv_vars,
++				key_thread_stdenv_vars_destroy);
+ 	if (status) {
+-		logerr("%s: failed to create thread data key for attempt ID!",
++		logerr("%s: failed to create thread data key for std env vars!",
+ 		       program);
+ 		master_kill(master_list);
+ 		res = write(start_pipefd[1], pst_stat, sizeof(*pst_stat));


### PR DESCRIPTION
When using automount with the debug flag it will segfault immediately due to pthread_getspecific being called with an uninitialized pthread_key by the info function.

This PR fixes that issue by moving the creation of the key_thread_attempt_id key above the first info call.

This problem only occurs with musl since glibc seems to be more forgiving. 