### PR TITLE
re-implement libc specific reopen_stream

### DIFF
--- a/sys-fs/lvm2/files/lvm2-2.02.183-implement-libc-specific-reopen_stream.patch
+++ b/sys-fs/lvm2/files/lvm2-2.02.183-implement-libc-specific-reopen_stream.patch
@@ -1,0 +1,24 @@
+diff --git a/lib/log/log.c b/lib/log/log.c
+index 79fbd7a..0999d10 100644
+--- a/lib/log/log.c
++++ b/lib/log/log.c
+@@ -161,6 +161,7 @@ static void _check_and_replace_standard_log_streams(FILE *old_stream, FILE *new_
+  * Close and reopen standard stream on file descriptor fd.
+  */
+ int reopen_standard_stream(FILE **stream, const char *mode)
++#ifdef __GLIBC__
+ {
+ 	int fd, fd_copy, new_fd;
+ 	const char *name;
+@@ -207,6 +208,11 @@ int reopen_standard_stream(FILE **stream, const char *mode)
+ 	*stream = new_stream;
+ 	return 1;
+ }
++#else
++{
++    return (freopen(NULL, mode, *stream) != NULL);
++}
++#endif
+ 
+ void init_log_fn(lvm2_log_fn_t log_fn)
+ {

--- a/sys-fs/lvm2/lvm2-2.02.183.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.183.ebuild
@@ -56,6 +56,7 @@ PATCHES=(
 	# Musl fixes
 	"${FILESDIR}"/${PN}-2.02.183-fix-stdio-usage.patch
 	"${FILESDIR}"/${PN}-2.02.183-portability.patch
+	"${FILESDIR}"/${PN}-2.02.183-implement-libc-specific-reopen_stream.patch
 
 	# For upstream -- review and forward:
 	"${FILESDIR}"/${PN}-2.02.63-always-make-static-libdm.patch


### PR DESCRIPTION
lvm2-2.02.183-fix-stdio-usage.patch leaves out an #ifdef from the original patch from 2016 (https://github.com/openembedded/meta-openembedded/blob/master/meta-oe/recipes-support/lvm2/files/0001-implement-libc-specific-reopen_stream.patch) which leads to segfaults on my machine. Reintroducing freopen fixes this (at least for me).