### PR TITLE
sys-apps/sandbox: drop to just musl arches

### DIFF
--- a/sys-apps/sandbox/sandbox-2.17.ebuild
+++ b/sys-apps/sandbox/sandbox-2.17.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://dev.gentoo.org/~dilfridge/distfiles/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~x86"
 IUSE=""
 
 DEPEND="app-arch/xz-utils


### PR DESCRIPTION
As done before for sandbox-2.15 (in commit ecccbd84f7ba545038597346fa4a9665783c3ae2)