### PR TITLE
sys-libs/pam: sync IUSE with ebuilds from tree

### DIFF
--- a/sys-libs/pam/pam-1.3.0-r2.ebuild
+++ b/sys-libs/pam/pam-1.3.0-r2.ebuild
@@ -16,7 +16,7 @@ SRC_URI="http://www.linux-pam.org/library/${MY_P}.tar.bz2
 LICENSE="|| ( BSD GPL-2 )"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ~mips ppc x86"
-IUSE="audit berkdb cracklib debug nis nls +pie selinux test vim-syntax"
+IUSE="audit berkdb +cracklib debug nis nls +pie selinux test vim-syntax"
 
 RDEPEND="
 	nls? ( >=virtual/libintl-0-r1[${MULTILIB_USEDEP}] )


### PR DESCRIPTION
there's a reason for it being preselected via USE="+cracklib" in tree.

Otherwise this beauty may happen: 

```
The following USE changes are necessary to proceed:
 (see "package.use" in the portage(5) man page for more details)
# required by sys-auth/pambase-20150213-r2::gentoo[cracklib]
# required by sys-apps/shadow-4.6::gentoo[pam]
# required by virtual/shadow-0::gentoo
# required by net-misc/openssh-7.9_p1-r4::gentoo
# required by gnome-base/gnome-keyring-3.28.2::gentoo[ssh-agent]
# required by app-crypt/libsecret-0.18.8::gentoo
# required by app-crypt/pinentry-1.1.0-r2::gentoo[gnome-keyring]
# required by app-crypt/gnupg-2.2.17::gentoo
# required by dev-vcs/git-2.21.0-r1::gentoo[gpg]
# required by sys-devel/gettext-0.19.8.1::gentoo[git]
# required by dev-libs/elfutils-0.176-r1::gentoo[nls]
# required by virtual/libelf-3::gentoo
# required by media-libs/mesa-19.0.8::gentoo
# required by virtual/opengl-7.0-r2::gentoo
# required by x11-libs/libva-1.7.3::gentoo
# required by x11-libs/libva-vdpau-driver-0.7.4-r5::gentoo
>=sys-libs/pam-1.3.0-r2 cracklib
```