### PR TITLE
*/*: drop unused/unsupported keywords

### DIFF
--- a/app-office/libreoffice/libreoffice-6.3.4.2.ebuild
+++ b/app-office/libreoffice/libreoffice-6.3.4.2.ebuild
@@ -79,7 +79,7 @@ RESTRICT="!test? ( test )"
 LICENSE="|| ( LGPL-3 MPL-1.1 )"
 SLOT="0"
 [[ ${MY_PV} == *9999* ]] || \
-KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 
 BDEPEND="
 	dev-util/intltool

--- a/app-text/enchant/enchant-1.6.1.ebuild
+++ b/app-text/enchant/enchant-1.6.1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/AbiWord/enchant/releases/download/${PN}-${MY_PV}/${P
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~x86"
 
 IUSE="aspell +hunspell static-libs test"
 RESTRICT="!test? ( test )"

--- a/dev-lang/ruby/ruby-2.4.4.ebuild
+++ b/dev-lang/ruby/ruby-2.4.4.ebuild
@@ -30,7 +30,7 @@ SRC_URI="mirror://ruby/${SLOT}/${MY_P}.tar.xz
 		 https://dev.gentoo.org/~graaff/ruby-team/${PN}-patches-${PATCHSET}.tar.bz2"
 
 LICENSE="|| ( Ruby-BSD BSD-2 )"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~x86"
 IUSE="berkdb debug doc examples gdbm ipv6 jemalloc libressl +rdoc rubytests socks5 ssl static-libs tk xemacs"
 
 RDEPEND="

--- a/dev-lang/ruby/ruby-2.5.1.ebuild
+++ b/dev-lang/ruby/ruby-2.5.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="mirror://ruby/${SLOT}/${MY_P}.tar.xz
 		 https://dev.gentoo.org/~graaff/ruby-team/${PN}-patches-${PATCHSET}.tar.bz2"
 
 LICENSE="|| ( Ruby-BSD BSD-2 )"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~x86"
 IUSE="berkdb debug doc examples gdbm ipv6 jemalloc libressl +rdoc rubytests socks5 ssl static-libs tk xemacs"
 
 RDEPEND="

--- a/dev-libs/elfutils/elfutils-0.176-r1.ebuild
+++ b/dev-libs/elfutils/elfutils-0.176-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://sourceware.org/elfutils/ftp/${PV}/${P}.tar.bz2"
 
 LICENSE="|| ( GPL-2+ LGPL-3+ ) utils? ( GPL-3+ )"
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 ~hppa ia64 m68k ~mips ppc ppc64 ~riscv s390 sh sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 x86"
 IUSE="bzip2 lzma nls static-libs test +threads +utils"
 RESTRICT="!test? ( test )"
 

--- a/dev-libs/elfutils/elfutils-0.178.ebuild
+++ b/dev-libs/elfutils/elfutils-0.178.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://sourceware.org/elfutils/ftp/${PV}/${P}.tar.bz2"
 
 LICENSE="|| ( GPL-2+ LGPL-3+ ) utils? ( GPL-3+ )"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="bzip2 lzma nls static-libs test +threads +utils valgrind"
 
 RDEPEND=">=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}]

--- a/dev-libs/libgamin/libgamin-0.1.10-r5.ebuild
+++ b/dev-libs/libgamin/libgamin-0.1.10-r5.ebuild
@@ -18,7 +18,7 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ia64 ~mips ppc ~sh sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE="debug kernel_linux python static-libs"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 

--- a/dev-libs/libnl/libnl-3.4.0.ebuild
+++ b/dev-libs/libnl/libnl-3.4.0.ebuild
@@ -17,7 +17,7 @@ SRC_URI="
 "
 LICENSE="LGPL-2.1 utils? ( GPL-2 )"
 SLOT="3"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 ~sh sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 x86"
 IUSE="+debug static-libs python +threads utils"
 
 RDEPEND="

--- a/dev-perl/Crypt-Rijndael/Crypt-Rijndael-1.130.0.ebuild
+++ b/dev-perl/Crypt-Rijndael/Crypt-Rijndael-1.130.0.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="Crypt::CBC compliant Rijndael encryption module"
 
 LICENSE="LGPL-3"
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm ~arm64 hppa ia64 ~mips ppc ppc64 sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="amd64 ~arm ~arm64 ~mips ppc ppc64 x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-tex/luatex/luatex-0.70.1-r3.ebuild
+++ b/dev-tex/luatex/luatex-0.70.1-r3.ebuild
@@ -12,7 +12,7 @@ SRC_URI="http://foundry.supelec.fr/gf/download/frsrelease/392/1730/${PN}-beta-${
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="amd64 arm ~mips ppc ppc64 x86"
 IUSE="doc"
 
 RDEPEND="dev-libs/zziplib

--- a/dev-util/cmocka/cmocka-1.1.3.ebuild
+++ b/dev-util/cmocka/cmocka-1.1.3.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://cmocka.org/files/1.1/${P}.tar.xz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="doc static-libs test"
 RESTRICT="!test? ( test )"
 

--- a/dev-util/systemtap/systemtap-2.9.ebuild
+++ b/dev-util/systemtap/systemtap-2.9.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://www.sourceware.org/${PN}/ftp/releases/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~x86"
 IUSE="sqlite"
 
 RDEPEND=">=dev-libs/elfutils-0.142

--- a/gnome-base/gnome-keyring/gnome-keyring-3.20.0.ebuild
+++ b/gnome-base/gnome-keyring/gnome-keyring-3.20.0.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://wiki.gnome.org/Projects/GnomeKeyring"
 LICENSE="GPL-2+ LGPL-2+"
 SLOT="0"
 IUSE="+caps pam selinux +ssh-agent test"
-KEYWORDS="amd64 arm arm64 ia64 ~mips ppc ~sh sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 
 # Replace gkd gpg-agent with pinentry[gnome-keyring] one, bug #547456
 RDEPEND="

--- a/gnome-base/gnome-session/gnome-session-3.22.3.ebuild
+++ b/gnome-base/gnome-session/gnome-session-3.22.3.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://git.gnome.org/browse/gnome-session"
 
 LICENSE="GPL-2 LGPL-2 FDL-1.1"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~arm64 ~ia64 ~ppc ~sparc x86"
+KEYWORDS="amd64 ~arm ~arm64 ~ppc x86"
 IUSE="doc ipv6 systemd"
 
 # x11-misc/xdg-user-dirs{,-gtk} are needed to create the various XDG_*_DIRs, and

--- a/mail-filter/libspf2/libspf2-1.2.10.ebuild
+++ b/mail-filter/libspf2/libspf2-1.2.10.ebuild
@@ -10,7 +10,7 @@ SRC_URI="http://www.libspf2.org/spf/libspf2-${PV}.tar.gz"
 
 LICENSE="|| ( LGPL-2.1 BSD-2 )"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="amd64 arm ppc ppc64 x86"
 IUSE="static static-libs"
 
 DEPEND=""

--- a/mail-filter/libspf2/libspf2-1.2.9-r3.ebuild
+++ b/mail-filter/libspf2/libspf2-1.2.9-r3.ebuild
@@ -10,7 +10,7 @@ SRC_URI="http://www.libspf2.org/spf/libspf2-${PV}.tar.gz"
 
 LICENSE="|| ( LGPL-2.1 BSD-2 )"
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="amd64 ppc ppc64 x86"
 IUSE="static static-libs"
 
 DEPEND=""

--- a/media-gfx/exiv2/exiv2-0.26_p20171104.ebuild
+++ b/media-gfx/exiv2/exiv2-0.26_p20171104.ebuild
@@ -11,7 +11,7 @@ if [[ ${PV} = *9999 ]]; then
 else
 	COMMIT=900d2417dbeb46e14cbf65fc2798ed1d043ab76d
 	SRC_URI="https://github.com/Exiv2/${PN}/tarball/${COMMIT} -> ${P}.tar.gz"
-	KEYWORDS="amd64 arm arm64 ia64 ~mips ppc ~sh sparc x86"
+	KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 fi
 inherit cmake-multilib python-any-r1 vcs-snapshot
 

--- a/media-gfx/exiv2/exiv2-0.26_p20180319.ebuild
+++ b/media-gfx/exiv2/exiv2-0.26_p20180319.ebuild
@@ -11,7 +11,7 @@ if [[ ${PV} = *9999 ]]; then
 else
 	COMMIT=876b1314ab892cbfa6672b6b94adbeb90db4211f
 	SRC_URI="https://github.com/Exiv2/${PN}/tarball/${COMMIT} -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~sh ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~x86"
 fi
 inherit cmake-multilib python-any-r1
 

--- a/media-libs/alsa-lib/alsa-lib-1.1.4.1.ebuild
+++ b/media-libs/alsa-lib/alsa-lib-1.1.4.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://alsaproject/lib/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~x86"
 IUSE="alisp debug doc elibc_uclibc python"
 
 RDEPEND="python? ( ${PYTHON_DEPS} )"

--- a/media-libs/alsa-lib/alsa-lib-1.1.5.ebuild
+++ b/media-libs/alsa-lib/alsa-lib-1.1.5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://alsaproject/lib/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~x86"
 IUSE="alisp debug doc elibc_uclibc python"
 
 RDEPEND="python? ( ${PYTHON_DEPS} )"

--- a/media-libs/alsa-lib/alsa-lib-1.1.6-r1.ebuild
+++ b/media-libs/alsa-lib/alsa-lib-1.1.6-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://alsaproject/lib/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 arm ~arm64 ~ia64 ~mips ppc ~sh sparc x86"
+KEYWORDS="amd64 arm ~arm64 ~mips ppc x86"
 IUSE="alisp debug doc elibc_uclibc python +thread-safety"
 
 RDEPEND="python? ( ${PYTHON_DEPS} )"

--- a/media-libs/libdc1394/libdc1394-2.2.5-r1.ebuild
+++ b/media-libs/libdc1394/libdc1394-2.2.5-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz
 
 LICENSE="LGPL-2.1"
 SLOT="2"
-KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="amd64 arm ~arm64 ppc ppc64 x86"
 IUSE="doc static-libs"
 
 RDEPEND="

--- a/media-libs/libepoxy/libepoxy-1.5.0.ebuild
+++ b/media-libs/libepoxy/libepoxy-1.5.0.ebuild
@@ -18,7 +18,7 @@ HOMEPAGE="https://github.com/anholt/libepoxy"
 if [[ ${PV} = 9999* ]]; then
 	SRC_URI=""
 else
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 	SRC_URI="https://github.com/anholt/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 fi
 

--- a/media-libs/mesa/mesa-19.2.8.ebuild
+++ b/media-libs/mesa/mesa-19.2.8.ebuild
@@ -19,7 +19,7 @@ if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://mesa.freedesktop.org/archive/${MY_P}.tar.xz"
-	KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~sparc-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 x86"
 fi
 
 LICENSE="MIT"

--- a/media-libs/mesa/mesa-19.3.4.ebuild
+++ b/media-libs/mesa/mesa-19.3.4.ebuild
@@ -19,7 +19,7 @@ if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://mesa.freedesktop.org/archive/${MY_P}.tar.xz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~sparc-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 fi
 
 LICENSE="MIT"

--- a/media-libs/mesa/mesa-20.0.0.ebuild
+++ b/media-libs/mesa/mesa-20.0.0.ebuild
@@ -19,7 +19,7 @@ if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://mesa.freedesktop.org/archive/${MY_P}.tar.xz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~sparc-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 fi
 
 LICENSE="MIT"

--- a/media-libs/openal/openal-1.18.2-r1.ebuild
+++ b/media-libs/openal/openal-1.18.2-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="http://kcat.strangesoft.net/openal-releases/${MY_P}.tar.bz2"
 
 LICENSE="LGPL-2+"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm ~arm64 ~mips ppc ppc64 x86"
 IUSE="
 	alsa coreaudio debug jack oss portaudio pulseaudio qt5
 	cpu_flags_x86_sse cpu_flags_x86_sse2 cpu_flags_x86_sse4_1

--- a/media-libs/zvbi/zvbi-0.2.35-r1.ebuild
+++ b/media-libs/zvbi/zvbi-0.2.35-r1.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="http://zapping.sourceforge.net"
 
 LICENSE="GPL-2 LGPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ia64 ppc sparc x86"
+KEYWORDS="amd64 arm arm64 ppc x86"
 IUSE="doc dvb nls static-libs v4l X"
 
 RDEPEND=">=media-libs/libpng-1.5.18:0=[${MULTILIB_USEDEP}]

--- a/media-sound/cdparanoia/cdparanoia-3.10.2-r6.ebuild
+++ b/media-sound/cdparanoia/cdparanoia-3.10.2-r6.ebuild
@@ -12,7 +12,7 @@ SRC_URI="http://downloads.xiph.org/releases/${PN}/${MY_P}.src.tgz
 
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ia64 ~mips ppc sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE="static-libs"
 
 RDEPEND=""

--- a/media-sound/mpd/mpd-0.21.18-r1.ebuild
+++ b/media-sound/mpd/mpd-0.21.18-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://www.musicpd.org/download/${PN}/${PV%.*}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ~ppc ~ppc64 ~sh x86 ~x64-macos"
+KEYWORDS="amd64 ~arm ~ppc ~ppc64 x86"
 IUSE="+alsa ao +audiofile bzip2 cdio chromaprint +cue +curl +dbus debug
 	+eventfd expat faad +ffmpeg +fifo flac fluidsynth gme +icu +id3tag +inotify
 	+ipv6 jack lame libav libmpdclient libsamplerate libsoxr +mad mikmod mms

--- a/media-sound/ncmpcpp/ncmpcpp-0.7.7.ebuild
+++ b/media-sound/ncmpcpp/ncmpcpp-0.7.7.ebuild
@@ -10,7 +10,7 @@ SRC_URI="${HOMEPAGE}stable/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ppc sparc x86"
+KEYWORDS="amd64 arm arm64 ppc x86"
 IUSE="clock curl outputs taglib unicode visualizer"
 
 RDEPEND="

--- a/media-sound/sox/sox-14.4.2.ebuild
+++ b/media-sound/sox/sox-14.4.2.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/sox/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ia64 ~mips ppc sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE="alsa amr ao debug encode flac id3tag ladspa mad ogg openmp oss opus png pulseaudio sndfile static-libs twolame wavpack"
 
 RDEPEND="

--- a/net-dialup/ppp/ppp-2.4.7-r3.ebuild
+++ b/net-dialup/ppp/ppp-2.4.7-r3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="ftp://ftp.samba.org/pub/ppp/${P}.tar.gz
 
 LICENSE="BSD GPL-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 arm arm64 ia64 ~mips ppc ~sh sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE="activefilter atm dhcp eap-tls gtk ipv6 libressl pam radius"
 
 DEPEND="activefilter? ( net-libs/libpcap )

--- a/net-fs/autofs/autofs-5.1.4.ebuild
+++ b/net-fs/autofs/autofs-5.1.4.ebuild
@@ -17,7 +17,7 @@ SRC_URI="
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="-dmalloc ldap +libtirpc mount-locking sasl"
 
 # USE="sasl" adds SASL support to the LDAP module which will not be build. If

--- a/net-fs/nfs-utils/nfs-utils-1.3.4-r1.ebuild
+++ b/net-fs/nfs-utils/nfs-utils-1.3.4-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/nfs/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 sh sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 x86"
 IUSE="caps ipv6 kerberos +libmount nfsdcld +nfsidmap +nfsv4 nfsv41 selinux tcpd +uuid"
 REQUIRED_USE="kerberos? ( nfsv4 )"
 RESTRICT="test" #315573

--- a/net-fs/nfs-utils/nfs-utils-2.3.1-r3.ebuild
+++ b/net-fs/nfs-utils/nfs-utils-2.3.1-r3.ebuild
@@ -15,7 +15,7 @@ if [[ "${PV}" = *_rc* ]] ; then
 	S="${WORKDIR}/${PN}-${PN}-${MY_PV}"
 else
 	SRC_URI="mirror://sourceforge/nfs/${P}.tar.bz2"
-	KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86"
+	KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 x86"
 fi
 
 LICENSE="GPL-2"

--- a/net-fs/nfs-utils/nfs-utils-2.3.3.ebuild
+++ b/net-fs/nfs-utils/nfs-utils-2.3.3.ebuild
@@ -15,7 +15,7 @@ if [[ "${PV}" = *_rc* ]] ; then
 	S="${WORKDIR}/${PN}-${PN}-${MY_PV}"
 else
 	SRC_URI="mirror://sourceforge/nfs/${P}.tar.bz2"
-	KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 sh sparc x86"
+	KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 x86"
 fi
 
 LICENSE="GPL-2"

--- a/net-fs/samba/samba-4.10.2.ebuild
+++ b/net-fs/samba/samba-4.10.2.ebuild
@@ -15,7 +15,7 @@ SRC_PATH="stable"
 
 SRC_URI="mirror://samba/${SRC_PATH}/${MY_P}.tar.gz"
 [[ ${PV} = *_rc* ]] || \
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 
 DESCRIPTION="Samba Suite Version 4"
 HOMEPAGE="https://www.samba.org/"

--- a/net-fs/samba/samba-4.5.16.ebuild
+++ b/net-fs/samba/samba-4.5.16.ebuild
@@ -16,7 +16,7 @@ SRC_PATH="stable"
 SRC_URI="mirror://samba/${SRC_PATH}/${MY_P}.tar.gz
 	https://dev.gentoo.org/~polynomial-c/samba-4.5.11-disable-python-patches.tar.xz"
 [[ ${PV} = *_rc* ]] || \
-KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="amd64 arm ~arm64 ppc ppc64 x86"
 
 DESCRIPTION="Samba Suite Version 4"
 HOMEPAGE="http://www.samba.org/"

--- a/net-libs/libndp/libndp-1.6-r1.ebuild
+++ b/net-libs/libndp/libndp-1.6-r1.ebuild
@@ -12,7 +12,7 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE=""
 
-KEYWORDS="amd64 arm arm64 ~ia64 ppc ~sparc x86"
+KEYWORDS="amd64 arm arm64 ppc x86"
 
 DEPEND=""
 RDEPEND=""

--- a/net-libs/libnfsidmap/libnfsidmap-0.25-r1.ebuild
+++ b/net-libs/libnfsidmap/libnfsidmap-0.25-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://www.citi.umich.edu/projects/nfsv4/linux/libnfsidmap/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 x86"
 IUSE="ldap static-libs"
 
 DEPEND="ldap? ( net-nds/openldap )"

--- a/net-libs/libnfsidmap/libnfsidmap-0.27.ebuild
+++ b/net-libs/libnfsidmap/libnfsidmap-0.27.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://fedorapeople.org/~steved/${PN}/${PV}/${P}.tar.bz2"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="ldap static-libs"
 
 DEPEND="ldap? ( net-nds/openldap )"

--- a/net-misc/networkmanager/networkmanager-1.16.2.ebuild
+++ b/net-misc/networkmanager/networkmanager-1.16.2.ebuild
@@ -27,7 +27,7 @@ REQUIRED_USE="
 	?? ( consolekit elogind systemd )
 "
 
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 
 # gobject-introspection-0.10.3 is needed due to gnome bug 642300
 # wpa_supplicant-0.7.3-r3 is needed due to bug 359271

--- a/net-misc/radvd/radvd-2.18.ebuild
+++ b/net-misc/radvd/radvd-2.18.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://v6web.litech.org/radvd/dist/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~x86"
 IUSE="selinux test"
 RESTRICT="!test? ( test )"
 

--- a/net-misc/rsync/rsync-3.1.3.ebuild
+++ b/net-misc/rsync/rsync-3.1.3.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://rsync.samba.org/ftp/rsync/src/${P}.tar.gz"
 LICENSE="GPL-3"
 SLOT="0"
 [[ ${PV} = *_pre* ]] || \
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 x86"
 IUSE="acl examples iconv ipv6 static stunnel xattr"
 
 LIB_DEPEND="acl? ( virtual/acl[static-libs(+)] )

--- a/net-misc/whois/whois-5.2.20.ebuild
+++ b/net-misc/whois/whois-5.2.20.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://debian/pool/main/w/whois/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm arm64 x86"
 IUSE="iconv idn nls"
 RESTRICT="test" #59327
 

--- a/net-misc/whois/whois-5.3.2.ebuild
+++ b/net-misc/whois/whois-5.3.2.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://debian/pool/main/w/whois/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm ~arm64 x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm ~arm64 x86"
 IUSE="iconv idn nls"
 RESTRICT="test" #59327
 

--- a/net-misc/whois/whois-5.4.0.ebuild
+++ b/net-misc/whois/whois-5.4.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://debian/pool/main/w/whois/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 IUSE="iconv idn nls"
 RESTRICT="test" #59327
 

--- a/net-vpn/ipsec-tools/ipsec-tools-0.8.2-r5.ebuild
+++ b/net-vpn/ipsec-tools/ipsec-tools-0.8.2-r5.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
 
 LICENSE="BSD GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm ~ia64 ~mips ppc ppc64 x86"
+KEYWORDS="amd64 arm ~mips ppc ppc64 x86"
 IUSE="hybrid idea ipv6 kerberos ldap libressl nat pam rc5 readline selinux stats"
 
 CDEPEND="

--- a/net-wireless/bluez/bluez-5.51.ebuild
+++ b/net-wireless/bluez/bluez-5.51.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://kernel/linux/bluetooth/${P}.tar.xz"
 
 LICENSE="GPL-2+ LGPL-2.1+"
 SLOT="0/3"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="btpclient cups doc debug deprecated extra-tools experimental +mesh midi +obex +readline selinux systemd test test-programs +udev user-session"
 
 # Since this release all remaining extra-tools need readline support, but this could

--- a/net-wireless/crda/crda-1.1.3-r1.ebuild
+++ b/net-wireless/crda/crda-1.1.3-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="http://linuxwireless.org/download/crda/${P}.tar.bz2"
 
 LICENSE="ISC"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ia64 ~mips ppc sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE=""
 
 RDEPEND="dev-libs/openssl:0

--- a/sys-apps/accountsservice/accountsservice-0.6.50-r1.ebuild
+++ b/sys-apps/accountsservice/accountsservice-0.6.50-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~ia64 ppc ppc64 ~sparc x86"
+KEYWORDS="amd64 arm arm64 ppc ppc64 x86"
 
 IUSE="doc consolekit elogind +introspection selinux systemd"
 REQUIRED_USE="^^ ( consolekit elogind systemd )"

--- a/sys-apps/attr/attr-2.4.47-r2.ebuild
+++ b/sys-apps/attr/attr-2.4.47-r2.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://nongnu/${PN}/${P}.src.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ia64 ~mips ppc sh sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE="nls static-libs"
 
 DEPEND="nls? ( sys-devel/gettext )

--- a/sys-apps/fakeroot/fakeroot-1.20.2-r1.ebuild
+++ b/sys-apps/fakeroot/fakeroot-1.20.2-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://debian/pool/main/${PN:0:1}/${PN}/${P/-/_}.orig.tar.bz2"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 IUSE="acl debug static-libs test"
 RESTRICT="!test? ( test )"
 

--- a/sys-apps/fakeroot/fakeroot-1.22.ebuild
+++ b/sys-apps/fakeroot/fakeroot-1.22.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://debian/pool/main/${PN:0:1}/${PN}/${P/-/_}.orig.tar.bz2"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm arm64 ppc ppc64 x86"
 IUSE="acl debug static-libs test"
 RESTRICT="!test? ( test )"
 

--- a/sys-apps/groff/groff-1.22.4.ebuild
+++ b/sys-apps/groff/groff-1.22.4.ebuild
@@ -15,7 +15,7 @@ SRC_URI="mirror://gnu/groff/${MY_P}.tar.gz
 LICENSE="GPL-2"
 SLOT="0"
 [[ "${PV}" == *_rc* ]] || \
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="examples X"
 
 RDEPEND="

--- a/sys-apps/iproute2/iproute2-5.2.0.ebuild
+++ b/sys-apps/iproute2/iproute2-5.2.0.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == "9999" ]] ; then
 	inherit git-r3
 else
 	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 fi
 
 DESCRIPTION="kernel routing and traffic control utilities"

--- a/sys-apps/pciutils/pciutils-3.6.0.ebuild
+++ b/sys-apps/pciutils/pciutils-3.6.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="ftp://atrey.karlin.mff.cuni.cz/pub/linux/pci/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~arm-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="dns +kmod static-libs +udev zlib"
 
 # Have the sub-libs in RDEPEND with [static-libs] since, logically,

--- a/sys-apps/tcp-wrappers/tcp-wrappers-7.6.22-r1.ebuild
+++ b/sys-apps/tcp-wrappers/tcp-wrappers-7.6.22-r1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="ftp://ftp.porcupine.org/pub/security/${MY_P}.tar.gz
 
 LICENSE="tcp_wrappers_license"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ia64 ~mips ppc sh sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE="ipv6 netgroups static-libs"
 
 RDEPEND=""

--- a/sys-apps/watchdog/watchdog-5.14.ebuild
+++ b/sys-apps/watchdog/watchdog-5.14.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~mips ppc sh ~sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE="nfs"
 
 DEPEND="nfs? ( net-libs/libtirpc )"

--- a/sys-apps/watchdog/watchdog-5.15.ebuild
+++ b/sys-apps/watchdog/watchdog-5.15.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~x86"
 IUSE="nfs"
 
 DEPEND="nfs? ( net-libs/libtirpc )"

--- a/sys-auth/nss-myhostname/nss-myhostname-0.3.ebuild
+++ b/sys-auth/nss-myhostname/nss-myhostname-0.3.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://0pointer.de/lennart/projects/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1+"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ia64 ppc sparc x86"
+KEYWORDS="amd64 arm arm64 ppc x86"
 IUSE=""
 
 COMMON_DEPEND=""

--- a/sys-auth/polkit/polkit-0.116-r1.ebuild
+++ b/sys-auth/polkit/polkit-0.116-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://www.freedesktop.org/software/${PN}/releases/${P}.tar.gz"
 
 LICENSE="LGPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="consolekit elogind examples gtk +introspection jit kde nls pam selinux systemd test"
 RESTRICT="!test? ( test )"
 

--- a/sys-block/parted/parted-3.2.ebuild
+++ b/sys-block/parted/parted-3.2.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://gnu/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ia64 ~mips ppc ~sh sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE="+debug device-mapper nls readline selinux static-libs"
 RESTRICT="test"
 

--- a/sys-block/thin-provisioning-tools/thin-provisioning-tools-0.7.0.ebuild
+++ b/sys-block/thin-provisioning-tools/thin-provisioning-tools-0.7.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/jthornber/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ia64 ~mips ppc ~sh sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE="static test"
 RESTRICT="!test? ( test )"
 

--- a/sys-block/thin-provisioning-tools/thin-provisioning-tools-0.7.5.ebuild
+++ b/sys-block/thin-provisioning-tools/thin-provisioning-tools-0.7.5.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/jthornber/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~x86"
 IUSE="static test"
 RESTRICT="!test? ( test )"
 

--- a/sys-block/thin-provisioning-tools/thin-provisioning-tools-0.7.6.ebuild
+++ b/sys-block/thin-provisioning-tools/thin-provisioning-tools-0.7.6.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/jthornber/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~x86"
 IUSE="static test"
 RESTRICT="!test? ( test )"
 

--- a/sys-boot/efibootmgr/efibootmgr-14.ebuild
+++ b/sys-boot/efibootmgr/efibootmgr-14.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/rhinstaller/efibootmgr/releases/download/${PV}/${P}.
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ia64 x86"
+KEYWORDS="amd64 x86"
 IUSE=""
 
 RDEPEND="sys-apps/pciutils

--- a/sys-fs/lvm2/lvm2-2.02.184-r4.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.184-r4.ebuild
@@ -11,7 +11,7 @@ SRC_URI="ftp://sourceware.org/pub/lvm2/${PN/lvm/LVM}.${PV}.tgz
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm ~arm64 hppa ia64 ~mips ppc ppc64 s390 ~sh sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm ~arm64 ~mips ppc ppc64 x86"
 IUSE="readline static static-libs systemd lvm2create_initrd sanlock selinux +udev +thin device-mapper-only"
 REQUIRED_USE="device-mapper-only? ( !lvm2create_initrd !sanlock !thin )
 	systemd? ( udev )"

--- a/sys-fs/lvm2/lvm2-2.02.184-r5.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.184-r5.ebuild
@@ -11,7 +11,7 @@ SRC_URI="ftp://sourceware.org/pub/lvm2/${PN/lvm/LVM}.${PV}.tgz
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 x86"
 IUSE="readline static static-libs systemd lvm2create_initrd sanlock selinux +udev +thin device-mapper-only"
 REQUIRED_USE="device-mapper-only? ( !lvm2create_initrd !sanlock !thin )
 	systemd? ( udev )"

--- a/sys-fs/lvm2/lvm2-2.02.186-r2.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.186-r2.ebuild
@@ -11,7 +11,7 @@ SRC_URI="ftp://sourceware.org/pub/lvm2/${PN/lvm/LVM}.${PV}.tgz
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="readline static static-libs systemd lvm2create_initrd sanlock selinux +udev +thin device-mapper-only"
 REQUIRED_USE="device-mapper-only? ( !lvm2create_initrd !sanlock !thin )
 	systemd? ( udev )"

--- a/sys-fs/udisks/udisks-2.7.4-r1.ebuild
+++ b/sys-fs/udisks/udisks-2.7.4-r1.ebuild
@@ -10,7 +10,7 @@ SRC_URI="https://github.com/storaged-project/${PN}/archive/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="2"
-KEYWORDS="alpha amd64 arm ~arm64 ia64 ppc ppc64 x86"
+KEYWORDS="amd64 arm ~arm64 ppc ppc64 x86"
 IUSE="acl cryptsetup debug elogind +gptfdisk +introspection lvm nls selinux systemd"
 
 REQUIRED_USE="?? ( elogind systemd )"

--- a/sys-kernel/dracut/dracut-045-r2.ebuild
+++ b/sys-kernel/dracut/dracut-045-r2.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://dracut.wiki.kernel.org"
 SRC_URI="mirror://kernel/linux/utils/boot/${PN}/${P}.tar.xz"
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~arm64 ia64 ~mips ppc sparc x86"
+KEYWORDS="amd64 ~arm ~arm64 ~mips ppc x86"
 IUSE="debug selinux"
 
 RESTRICT="test"

--- a/sys-kernel/dracut/dracut-046-r1.ebuild
+++ b/sys-kernel/dracut/dracut-046-r1.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://dracut.wiki.kernel.org"
 SRC_URI="mirror://kernel/linux/utils/boot/${PN}/${P}.tar.xz"
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~arm64 ia64 ~mips ppc sparc x86"
+KEYWORDS="amd64 ~arm ~arm64 ~mips ppc x86"
 IUSE="debug selinux"
 
 RESTRICT="test"

--- a/sys-kernel/dracut/dracut-048-r1.ebuild
+++ b/sys-kernel/dracut/dracut-048-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://kernel/linux/utils/boot/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="debug selinux"
 
 # Tests need root privileges, bug #298014

--- a/sys-kernel/dracut/dracut-049-r1.ebuild
+++ b/sys-kernel/dracut/dracut-049-r1.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/dracutdevs/dracut"
 else
 	[[ "${PV}" = *_rc* ]] || \
-	KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~x86"
 	SRC_URI="https://github.com/dracutdevs/dracut/archive/${PV}.tar.gz -> ${P}.tar.gz"
 fi
 

--- a/sys-libs/gpm/gpm-1.20.7-r2.ebuild
+++ b/sys-libs/gpm/gpm-1.20.7-r2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="http://www.nico.schottelius.org/software/${PN}/archives/${P}.tar.lzma
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ia64 ~mips ppc sh sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE="selinux static-libs"
 
 RDEPEND=">=sys-libs/ncurses-5.9-r3:0=[${MULTILIB_USEDEP}]

--- a/sys-libs/ldb/ldb-1.1.29-r1.ebuild
+++ b/sys-libs/ldb/ldb-1.1.29-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://www.samba.org/ftp/pub/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-3"
 SLOT="0/${PV}"
-KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86"
+KEYWORDS="amd64 arm ~arm64 ~mips ppc ppc64 x86"
 IUSE="doc +ldap +python"
 
 RDEPEND="dev-libs/libbsd[${MULTILIB_USEDEP}]

--- a/sys-libs/ldb/ldb-1.1.31.ebuild
+++ b/sys-libs/ldb/ldb-1.1.31.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://www.samba.org/ftp/pub/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-3"
 SLOT="0/${PV}"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="doc +ldap +python"
 
 RDEPEND="dev-libs/libbsd[${MULTILIB_USEDEP}]

--- a/sys-libs/ldb/ldb-1.2.4.ebuild
+++ b/sys-libs/ldb/ldb-1.2.4.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://www.samba.org/ftp/pub/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-3"
 SLOT="0/${PV}"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="doc +ldap +python"
 
 RDEPEND="dev-libs/libbsd[${MULTILIB_USEDEP}]

--- a/sys-libs/ldb/ldb-1.3.6.ebuild
+++ b/sys-libs/ldb/ldb-1.3.6.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://www.samba.org/ftp/pub/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-3"
 SLOT="0/${PV}"
-KEYWORDS="~alpha amd64 ~arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh ~sparc x86"
+KEYWORDS="amd64 ~arm ~arm64 ~mips ppc ppc64 x86"
 IUSE="doc +ldap +python"
 
 RDEPEND="

--- a/sys-libs/ldb/ldb-1.3.8.ebuild
+++ b/sys-libs/ldb/ldb-1.3.8.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://www.samba.org/ftp/pub/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-3"
 SLOT="0/${PV}"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 x86"
 IUSE="doc +ldap +python"
 
 RDEPEND="

--- a/sys-libs/ldb/ldb-1.4.7.ebuild
+++ b/sys-libs/ldb/ldb-1.4.7.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://www.samba.org/ftp/pub/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-3"
 SLOT="0/${PV}"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="doc +ldap +lmdb +python"
 
 RDEPEND="

--- a/sys-libs/ldb/ldb-1.5.5.ebuild
+++ b/sys-libs/ldb/ldb-1.5.5.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://www.samba.org/ftp/pub/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-3"
 SLOT="0/${PV}"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="doc +ldap +lmdb +python"
 
 RDEPEND="

--- a/sys-libs/libblockdev/libblockdev-2.14-r1.ebuild
+++ b/sys-libs/libblockdev/libblockdev-2.14-r1.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://github.com/storaged-project/libblockdev"
 SRC_URI="https://github.com/storaged-project/${PN}/archive/${MY_PV}.tar.gz -> ${MY_P}.tar.gz"
 LICENSE="LGPL-2+"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 ia64 ppc ppc64 ~sparc x86"
+KEYWORDS="amd64 arm ~arm64 ppc ppc64 x86"
 IUSE="bcache +cryptsetup dmraid doc lvm kbd test"
 RESTRICT="!test? ( test )"
 

--- a/sys-libs/libcap/libcap-2.28-r1.ebuild
+++ b/sys-libs/libcap/libcap-2.28-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/${P}
 # it's available under either of the licenses
 LICENSE="|| ( GPL-2 BSD )"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="pam static-libs"
 
 # While the build system optionally uses gperf, we don't DEPEND on it because

--- a/sys-libs/ntdb/ntdb-1.0-r1.ebuild
+++ b/sys-libs/ntdb/ntdb-1.0-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="http://samba.org/ftp/tdb/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ia64 ppc sparc x86"
+KEYWORDS="amd64 arm arm64 ppc x86"
 IUSE="python"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"

--- a/sys-libs/slang/slang-2.3.0.ebuild
+++ b/sys-libs/slang/slang-2.3.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://www.jedsoft.org/releases/${PN}/${P}.tar.bz2
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ia64 ~mips ppc ~sh sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE="cjk pcre png readline static-libs zlib"
 
 # ncurses for ncurses5-config to get terminfo directory

--- a/sys-process/psmisc/psmisc-23.1-r1.ebuild
+++ b/sys-process/psmisc/psmisc-23.1-r1.ebuild
@@ -9,7 +9,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 x86"
 IUSE="ipv6 nls selinux X"
 
 RDEPEND=">=sys-libs/ncurses-5.7-r7:0=

--- a/x11-apps/sessreg/sessreg-1.1.1.ebuild
+++ b/x11-apps/sessreg/sessreg-1.1.1.ebuild
@@ -6,7 +6,7 @@ inherit xorg-2
 
 DESCRIPTION="manage utmp/wtmp entries for non-init clients"
 
-KEYWORDS="amd64 arm arm64 ia64 ~mips ppc ~sh sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE=""
 
 RDEPEND=""

--- a/x11-libs/libpciaccess/libpciaccess-0.13.4.ebuild
+++ b/x11-libs/libpciaccess/libpciaccess-0.13.4.ebuild
@@ -7,7 +7,7 @@ XORG_MULTILIB=yes
 inherit xorg-2
 
 DESCRIPTION="Library providing generic access to the PCI bus and devices"
-KEYWORDS="amd64 arm arm64 ia64 ~mips ppc ~sh sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE="zlib"
 
 DEPEND="!<x11-base/xorg-server-1.5

--- a/x11-libs/vte/vte-0.28.2-r208.ebuild
+++ b/x11-libs/vte/vte-0.28.2-r208.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://wiki.gnome.org/Apps/Terminal/VTE"
 
 LICENSE="LGPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~mips ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~x86"
 IUSE="debug +introspection python"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 

--- a/x11-misc/slim/slim-1.3.6-r5.ebuild
+++ b/x11-misc/slim/slim-1.3.6-r5.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://sourceforge/project/${PN}.berlios/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~mips ppc sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc x86"
 IUSE="branding pam consolekit"
 REQUIRED_USE="consolekit? ( pam )"
 

--- a/x11-wm/fluxbox/fluxbox-1.3.7-r4.ebuild
+++ b/x11-wm/fluxbox/fluxbox-1.3.7-r4.ebuild
@@ -15,7 +15,7 @@ SRC_URI="mirror://sourceforge/fluxbox/${P}.tar.xz"
 HOMEPAGE="http://www.fluxbox.org"
 SLOT="0"
 LICENSE="MIT"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~x86"
 
 RDEPEND="
 	!!<=x11-misc/fbdesk-1.2.1


### PR DESCRIPTION
main tree dropped stable alpha keywords
Even I have access now, I did not want to commit something like that right away =)

should help with getting travis/repoman back to normal.