### PR TITLE
Add chromium and firefox musl scripts from smaeul and jakeogh

### DIFF
--- a/www-client/chromium/chromium-75.0.3770.100.ebuild
+++ b/www-client/chromium/chromium-75.0.3770.100.ebuild
@@ -1,0 +1,744 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python2_7 )
+
+CHROMIUM_LANGS="am ar bg bn ca cs da de el en-GB es es-419 et fa fi fil fr gu he
+	hi hr hu id it ja kn ko lt lv ml mr ms nb nl pl pt-BR pt-PT ro ru sk sl sr
+	sv sw ta te th tr uk vi zh-CN zh-TW"
+
+inherit check-reqs chromium-2 desktop flag-o-matic multilib ninja-utils pax-utils portability python-any-r1 readme.gentoo-r1 toolchain-funcs xdg-utils
+
+DESCRIPTION="Open-source version of Google Chrome web browser"
+HOMEPAGE="http://chromium.org/"
+SRC_URI="https://commondatastorage.googleapis.com/chromium-browser-official/${P}.tar.xz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="amd64 ~x86"
+IUSE="+atk +closure-compile component-build cups +dbus gnome-keyring +hangouts jumbo-build kerberos neon pic +proprietary-codecs pulseaudio selinux +suid +system-ffmpeg +system-icu +system-libvpx +tcmalloc widevine"
+RESTRICT="!system-ffmpeg? ( proprietary-codecs? ( bindist ) )"
+
+REQUIRED_USE="atk? ( dbus )
+	component-build? ( !suid )"
+
+COMMON_DEPEND="
+	atk? ( >=app-accessibility/at-spi2-atk-2.26:2 )
+	app-arch/bzip2:=
+	cups? ( >=net-print/cups-1.3.11:= )
+	atk? ( >=dev-libs/atk-2.26 )
+	dev-libs/expat:=
+	dev-libs/glib:2
+	system-icu? ( >=dev-libs/icu-64:= )
+	>=dev-libs/libxml2-2.9.4-r3:=[icu]
+	dev-libs/libxslt:=
+	dev-libs/nspr:=
+	>=dev-libs/nss-3.26:=
+	>=dev-libs/re2-0.2016.11.01:=
+	gnome-keyring? ( >=gnome-base/libgnome-keyring-3.12:= )
+	>=media-libs/alsa-lib-1.0.19:=
+	media-libs/fontconfig:=
+	media-libs/freetype:=
+	>=media-libs/harfbuzz-2.2.0:0=[icu(-)]
+	media-libs/libjpeg-turbo:=
+	media-libs/libpng:=
+	system-libvpx? ( media-libs/libvpx:=[postproc,svc] )
+	>=media-libs/openh264-1.6.0:=
+	pulseaudio? ( media-sound/pulseaudio:= )
+	system-ffmpeg? (
+		>=media-video/ffmpeg-4:=
+		|| (
+			media-video/ffmpeg[-samba]
+			>=net-fs/samba-4.5.10-r1[-debug(-)]
+		)
+		!=net-fs/samba-4.5.12-r0
+		media-libs/opus:=
+	)
+	dbus? ( sys-apps/dbus:= )
+	sys-apps/pciutils:=
+	virtual/udev
+	x11-libs/cairo:=
+	x11-libs/gdk-pixbuf:2
+	x11-libs/gtk+:3[X]
+	x11-libs/libX11:=
+	x11-libs/libXcomposite:=
+	x11-libs/libXcursor:=
+	x11-libs/libXdamage:=
+	x11-libs/libXext:=
+	x11-libs/libXfixes:=
+	>=x11-libs/libXi-1.6.0:=
+	x11-libs/libXrandr:=
+	x11-libs/libXrender:=
+	x11-libs/libXScrnSaver:=
+	x11-libs/libXtst:=
+	x11-libs/pango:=
+	app-arch/snappy:=
+	media-libs/flac:=
+	>=media-libs/libwebp-0.4.0:=
+	sys-libs/zlib:=[minizip]
+	kerberos? ( virtual/krb5 )
+"
+# For nvidia-drivers blocker, see bug #413637 .
+RDEPEND="${COMMON_DEPEND}
+	!<www-plugins/chrome-binary-plugins-57
+	x11-misc/xdg-utils
+	virtual/opengl
+	virtual/ttf-fonts
+	selinux? ( sec-policy/selinux-chromium )
+	tcmalloc? ( !<x11-drivers/nvidia-drivers-331.20 )
+	widevine? ( www-plugins/chrome-binary-plugins[widevine(-)] )
+"
+# dev-vcs/git - https://bugs.gentoo.org/593476
+# sys-apps/sandbox - https://crbug.com/586444
+DEPEND="${COMMON_DEPEND}
+"
+BDEPEND="
+	>=app-arch/gzip-1.7
+	amd64? (
+		dev-lang/yasm
+	)
+	x86? (
+		dev-lang/yasm
+	)
+	dev-lang/perl
+	<dev-util/gn-0.1583
+	dev-vcs/git
+	>=dev-util/gperf-3.0.3
+	>=dev-util/ninja-1.7.2
+	>=net-libs/nodejs-7.6.0[inspector]
+	sys-apps/hwids[usb(+)]
+	>=sys-devel/bison-2.4.3
+	sys-devel/flex
+	elibc_musl? ( sys-libs/queue-standalone )
+	closure-compile? ( virtual/jre )
+	virtual/pkgconfig
+"
+
+: ${CHROMIUM_FORCE_CLANG=no}
+
+if [[ ${CHROMIUM_FORCE_CLANG} == yes ]]; then
+	BDEPEND+=" >=sys-devel/clang-7"
+fi
+
+if ! has chromium_pkg_die ${EBUILD_DEATH_HOOKS}; then
+	EBUILD_DEATH_HOOKS+=" chromium_pkg_die";
+fi
+
+DISABLE_AUTOFORMATTING="yes"
+DOC_CONTENTS="
+Some web pages may require additional fonts to display properly.
+Try installing some of the following packages if some characters
+are not displayed properly:
+- media-fonts/arphicfonts
+- media-fonts/droid
+- media-fonts/ipamonafont
+- media-fonts/noto
+- media-fonts/ja-ipafonts
+- media-fonts/takao-fonts
+- media-fonts/wqy-microhei
+- media-fonts/wqy-zenhei
+To fix broken icons on the Downloads page, you should install an icon
+theme that covers the appropriate MIME types, and configure this as your
+GTK+ icon theme.
+For native file dialogs in KDE, install kde-apps/kdialog.
+"
+
+PATCHES=(
+	"${FILESDIR}/chromium-compiler-r9.patch"
+	"${FILESDIR}/chromium-widevine-r4.patch"
+	"${FILESDIR}/chromium-fix-char_traits.patch"
+	"${FILESDIR}/chromium-75-fix-gn-gen.patch"
+	"${FILESDIR}/chromium-75-gcc-angle-fix.patch"
+	"${FILESDIR}/chromium-75-unique_ptr.patch"
+	"${FILESDIR}/chromium-75-lss.patch"
+	"${FILESDIR}/chromium-75-noexcept.patch"
+	"${FILESDIR}/chromium-75-llvm8.patch"
+	"${FILESDIR}/chromium-75-pure-virtual.patch"
+	"${FILESDIR}/chromium-optional-atk-r1.patch"
+	"${FILESDIR}/chromium-optional-dbus-r5.patch"
+	"${FILESDIR}/chromium-url-formatter.patch"
+	"${FILESDIR}/musl-cdefs-r2.patch"
+	"${FILESDIR}/musl-dlopen.patch"
+	"${FILESDIR}/musl-dns-r2.patch"
+	"${FILESDIR}/musl-execinfo-r8.patch"
+	"${FILESDIR}/musl-fpstate-r1.patch"
+	"${FILESDIR}/musl-headers-r1.patch"
+	"${FILESDIR}/musl-libcpp.patch"
+	"${FILESDIR}/musl-mallinfo-r7.patch"
+	"${FILESDIR}/musl-pthread-r5.patch"
+	"${FILESDIR}/musl-ptrace.patch"
+	"${FILESDIR}/musl-realpath.patch"
+	"${FILESDIR}/musl-sandbox-r3.patch"
+	"${FILESDIR}/musl-secure_getenv-r1.patch"
+	"${FILESDIR}/musl-siginfo.patch"
+	"${FILESDIR}/musl-socket.patch"
+	"${FILESDIR}/musl-stacksize-r3.patch"
+	"${FILESDIR}/musl-stacktrace-r2.patch"
+	"${FILESDIR}/musl-syscall.patch"
+	"${FILESDIR}/musl-ucontext-r1.patch"
+	"${FILESDIR}/musl-v8-monotonic-pthread-cont_timedwait.patch"
+	"${FILESDIR}/musl-wordsize-r1.patch"
+)
+
+pre_build_checks() {
+	if [[ ${MERGE_TYPE} != binary ]]; then
+		local -x CPP="$(tc-getCXX) -E"
+		if tc-is-gcc && ! ver_test "$(gcc-version)" -ge 8.0; then
+			die "At least gcc 8.0 is required"
+		fi
+	fi
+
+	# Check build requirements, bug #541816 and bug #471810 .
+	CHECKREQS_MEMORY="3G"
+	CHECKREQS_DISK_BUILD="5G"
+	if ( shopt -s extglob; is-flagq '-g?(gdb)?([1-9])' ); then
+		CHECKREQS_DISK_BUILD="25G"
+		if ! use component-build; then
+			CHECKREQS_MEMORY="16G"
+		fi
+	fi
+	check-reqs_pkg_setup
+}
+
+pkg_pretend() {
+	pre_build_checks
+}
+
+pkg_setup() {
+	pre_build_checks
+
+	chromium_suid_sandbox_check_kernel_config
+}
+
+src_prepare() {
+	# Calling this here supports resumption via FEATURES=keepwork
+	python_setup
+
+	default
+
+	mkdir -p third_party/node/linux/node-linux-x64/bin || die
+	ln -s "${EPREFIX}"/usr/bin/node third_party/node/linux/node-linux-x64/bin/node || die
+
+	# These can cause the final link to take several hours.
+	filter-ldflags "*sort*"
+
+	local keeplibs=(
+		base/third_party/dmg_fp
+		base/third_party/dynamic_annotations
+		base/third_party/icu
+		base/third_party/nspr
+		base/third_party/superfasthash
+		base/third_party/symbolize
+		base/third_party/valgrind
+		base/third_party/xdg_mime
+		base/third_party/xdg_user_dirs
+		buildtools/third_party/libc++
+		buildtools/third_party/libc++abi
+		chrome/third_party/mozilla_security_manager
+		courgette/third_party
+		net/third_party/mozilla_security_manager
+		net/third_party/nss
+		net/third_party/quic
+		net/third_party/uri_template
+		third_party/abseil-cpp
+		third_party/angle
+		third_party/angle/src/common/third_party/base
+		third_party/angle/src/common/third_party/smhasher
+		third_party/angle/src/common/third_party/xxhash
+		third_party/angle/src/third_party/compiler
+		third_party/angle/src/third_party/libXNVCtrl
+		third_party/angle/src/third_party/trace_event
+		third_party/angle/third_party/glslang
+		third_party/angle/third_party/spirv-headers
+		third_party/angle/third_party/spirv-tools
+		third_party/angle/third_party/vulkan-headers
+		third_party/angle/third_party/vulkan-loader
+		third_party/angle/third_party/vulkan-tools
+		third_party/angle/third_party/vulkan-validation-layers
+		third_party/apple_apsl
+		third_party/axe-core
+		third_party/blink
+		third_party/boringssl
+		third_party/boringssl/src/third_party/fiat
+		third_party/breakpad
+		third_party/breakpad/breakpad/src/third_party/curl
+		third_party/brotli
+		third_party/cacheinvalidation
+		third_party/catapult
+		third_party/catapult/common/py_vulcanize/third_party/rcssmin
+		third_party/catapult/common/py_vulcanize/third_party/rjsmin
+		third_party/catapult/third_party/beautifulsoup4
+		third_party/catapult/third_party/html5lib-python
+		third_party/catapult/third_party/polymer
+		third_party/catapult/third_party/six
+		third_party/catapult/tracing/third_party/d3
+		third_party/catapult/tracing/third_party/gl-matrix
+		third_party/catapult/tracing/third_party/jszip
+		third_party/catapult/tracing/third_party/mannwhitneyu
+		third_party/catapult/tracing/third_party/oboe
+		third_party/catapult/tracing/third_party/pako
+		third_party/ced
+		third_party/cld_3
+		third_party/closure_compiler
+		third_party/crashpad
+		third_party/crashpad/crashpad/third_party/zlib
+		third_party/crc32c
+		third_party/cros_system_api
+		third_party/dav1d
+		third_party/dawn
+		third_party/devscripts
+		third_party/dom_distiller_js
+		third_party/emoji-segmenter
+		third_party/flatbuffers
+		third_party/flot
+		third_party/freetype
+		third_party/glslang
+		third_party/google_input_tools
+		third_party/google_input_tools/third_party/closure_library
+		third_party/google_input_tools/third_party/closure_library/third_party/closure
+		third_party/googletest
+		third_party/hunspell
+		third_party/iccjpeg
+		third_party/inspector_protocol
+		third_party/jinja2
+		third_party/jsoncpp
+		third_party/jstemplate
+		third_party/khronos
+		third_party/leveldatabase
+		third_party/libXNVCtrl
+		third_party/libaddressinput
+		third_party/libaom
+		third_party/libaom/source/libaom/third_party/vector
+		third_party/libaom/source/libaom/third_party/x86inc
+		third_party/libjingle
+		third_party/libphonenumber
+		third_party/libsecret
+		third_party/libsrtp
+		third_party/libsync
+		third_party/libudev
+		third_party/libwebm
+		third_party/libxml/chromium
+		third_party/libyuv
+		third_party/llvm
+		third_party/lss
+		third_party/lzma_sdk
+		third_party/markupsafe
+		third_party/mesa
+		third_party/metrics_proto
+		third_party/modp_b64
+		third_party/nasm
+		third_party/node
+		third_party/node/node_modules/polymer-bundler/lib/third_party/UglifyJS2
+		third_party/openmax_dl
+		third_party/ots
+		third_party/pdfium
+		third_party/pdfium/third_party/agg23
+		third_party/pdfium/third_party/base
+		third_party/pdfium/third_party/bigint
+		third_party/pdfium/third_party/freetype
+		third_party/pdfium/third_party/lcms
+		third_party/pdfium/third_party/libopenjpeg20
+		third_party/pdfium/third_party/libpng16
+		third_party/pdfium/third_party/libtiff
+		third_party/pdfium/third_party/skia_shared
+		third_party/perfetto
+		third_party/pffft
+		third_party/ply
+		third_party/polymer
+		third_party/protobuf
+		third_party/protobuf/third_party/six
+		third_party/pyjson5
+		third_party/qcms
+		third_party/rnnoise
+		third_party/s2cellid
+		third_party/sfntly
+		third_party/simplejson
+		third_party/skia
+		third_party/skia/include/third_party/vulkan
+		third_party/skia/third_party/gif
+		third_party/skia/third_party/skcms
+		third_party/skia/third_party/vulkan
+		third_party/smhasher
+		third_party/spirv-headers
+		third_party/SPIRV-Tools
+		third_party/sqlite
+		third_party/swiftshader
+		third_party/swiftshader/third_party/llvm-7.0
+		third_party/swiftshader/third_party/llvm-subzero
+		third_party/swiftshader/third_party/subzero
+		third_party/unrar
+		third_party/usrsctp
+		third_party/vulkan
+		third_party/web-animations-js
+		third_party/webdriver
+		third_party/webrtc
+		third_party/webrtc/common_audio/third_party/fft4g
+		third_party/webrtc/common_audio/third_party/spl_sqrt_floor
+		third_party/webrtc/modules/third_party/fft
+		third_party/webrtc/modules/third_party/g711
+		third_party/webrtc/modules/third_party/g722
+		third_party/webrtc/rtc_base/third_party/base64
+		third_party/webrtc/rtc_base/third_party/sigslot
+		third_party/widevine
+		third_party/woff2
+		third_party/zlib/google
+		url/third_party/mozilla
+		v8/src/third_party/siphash
+		v8/src/third_party/valgrind
+		v8/src/third_party/utf8-decoder
+		v8/third_party/inspector_protocol
+		v8/third_party/v8
+
+		# gyp -> gn leftovers
+		base/third_party/libevent
+		third_party/adobe
+		third_party/speech-dispatcher
+		third_party/usb_ids
+		third_party/xdg-utils
+		third_party/yasm/run_yasm.py
+	)
+	if ! use system-ffmpeg; then
+		keeplibs+=( third_party/ffmpeg third_party/opus )
+	fi
+	if ! use system-icu; then
+		keeplibs+=( third_party/icu )
+	fi
+	if ! use system-libvpx; then
+		keeplibs+=( third_party/libvpx )
+		keeplibs+=( third_party/libvpx/source/libvpx/third_party/x86inc )
+	fi
+	if use tcmalloc; then
+		keeplibs+=( third_party/tcmalloc )
+	fi
+
+	# Remove most bundled libraries. Some are still needed.
+	build/linux/unbundle/remove_bundled_libraries.py "${keeplibs[@]}" --do-remove || die
+}
+
+src_configure() {
+	# Calling this here supports resumption via FEATURES=keepwork
+	python_setup
+
+	local myconf_gn=""
+
+	# Make sure the build system will use the right tools, bug #340795.
+	tc-export AR CC CXX NM
+
+	if [[ ${CHROMIUM_FORCE_CLANG} == yes ]] && ! tc-is-clang; then
+		# Force clang since gcc is pretty broken at the moment.
+		CC=${CHOST}-clang
+		CXX=${CHOST}-clang++
+		strip-unsupported-flags
+	fi
+
+	if tc-is-clang; then
+		myconf_gn+=" is_clang=true clang_use_chrome_plugins=false"
+	else
+		myconf_gn+=" is_clang=false"
+	fi
+
+	# Define a custom toolchain for GN
+	myconf_gn+=" custom_toolchain=\"//build/toolchain/linux/unbundle:default\""
+
+	if tc-is-cross-compiler; then
+		tc-export BUILD_{AR,CC,CXX,NM}
+		myconf_gn+=" host_toolchain=\"//build/toolchain/linux/unbundle:host\""
+		myconf_gn+=" v8_snapshot_toolchain=\"//build/toolchain/linux/unbundle:host\""
+	else
+		myconf_gn+=" host_toolchain=\"//build/toolchain/linux/unbundle:default\""
+	fi
+
+	# GN needs explicit config for Debug/Release as opposed to inferring it from build directory.
+	myconf_gn+=" is_debug=false"
+
+	# Component build isn't generally intended for use by end users. It's mostly useful
+	# for development and debugging.
+	myconf_gn+=" is_component_build=$(usex component-build true false)"
+
+	# https://chromium.googlesource.com/chromium/src/+/lkcr/docs/jumbo.md
+	myconf_gn+=" use_jumbo_build=$(usex jumbo-build true false)"
+
+	myconf_gn+=" use_allocator=$(usex tcmalloc \"tcmalloc\" \"none\")"
+
+	# Disable nacl, we can't build without pnacl (http://crbug.com/269560).
+	myconf_gn+=" enable_nacl=false"
+
+	# Use system-provided libraries.
+	# TODO: freetype -- remove sources (https://bugs.chromium.org/p/pdfium/issues/detail?id=733).
+	# TODO: use_system_hunspell (upstream changes needed).
+	# TODO: use_system_libsrtp (bug #459932).
+	# TODO: use_system_protobuf (bug #525560).
+	# TODO: use_system_ssl (http://crbug.com/58087).
+	# TODO: use_system_sqlite (http://crbug.com/22208).
+
+	# libevent: https://bugs.gentoo.org/593458
+	local gn_system_libraries=(
+		flac
+		fontconfig
+		freetype
+		# Need harfbuzz_from_pkgconfig target
+		#harfbuzz-ng
+		libdrm
+		libjpeg
+		libpng
+		libwebp
+		libxml
+		libxslt
+		openh264
+		re2
+		snappy
+		yasm
+		zlib
+	)
+	if use system-ffmpeg; then
+		gn_system_libraries+=( ffmpeg opus )
+	fi
+	if use system-icu; then
+		gn_system_libraries+=( icu )
+	fi
+	if use system-libvpx; then
+		gn_system_libraries+=( libvpx )
+	fi
+	build/linux/unbundle/replace_gn_files.py --system-libraries "${gn_system_libraries[@]}" || die
+
+	# See dependency logic in third_party/BUILD.gn
+	myconf_gn+=" use_system_harfbuzz=true"
+
+	# Optional dependencies.
+	myconf_gn+=" closure_compile=$(usex closure-compile true false)"
+	myconf_gn+=" enable_hangout_services_extension=$(usex hangouts true false)"
+	myconf_gn+=" enable_widevine=$(usex widevine true false)"
+	myconf_gn+=" use_atk=$(usex atk true false)"
+	myconf_gn+=" use_cups=$(usex cups true false)"
+	myconf_gn+=" use_dbus=$(usex dbus true false)"
+	myconf_gn+=" use_gnome_keyring=$(usex gnome-keyring true false)"
+	myconf_gn+=" use_kerberos=$(usex kerberos true false)"
+	myconf_gn+=" use_pulseaudio=$(usex pulseaudio true false)"
+
+	# TODO: link_pulseaudio=true for GN.
+
+	myconf_gn+=" fieldtrial_testing_like_official_build=true"
+
+	# Never use bundled gold binary. Disable gold linker flags for now.
+	# Do not use bundled clang.
+	# Trying to use gold results in linker crash.
+	myconf_gn+=" use_gold=false use_sysroot=false linux_use_bundled_binutils=false use_custom_libcxx=false"
+
+	# Disable forced lld, bug 641556
+	myconf_gn+=" use_lld=false"
+
+	ffmpeg_branding="$(usex proprietary-codecs Chrome Chromium)"
+	myconf_gn+=" proprietary_codecs=$(usex proprietary-codecs true false)"
+	myconf_gn+=" ffmpeg_branding=\"${ffmpeg_branding}\""
+
+	# Set up Google API keys, see http://www.chromium.org/developers/how-tos/api-keys .
+	# Note: these are for Gentoo use ONLY. For your own distribution,
+	# please get your own set of keys. Feel free to contact chromium@gentoo.org
+	# for more info.
+	local google_api_key="AIzaSyDEAOvatFo0eTgsV_ZlEzx0ObmepsMzfAc"
+	local google_default_client_id="329227923882.apps.googleusercontent.com"
+	local google_default_client_secret="vgKG0NNv7GoDpbtoFNLxCUXu"
+	myconf_gn+=" google_api_key=\"${google_api_key}\""
+	myconf_gn+=" google_default_client_id=\"${google_default_client_id}\""
+	myconf_gn+=" google_default_client_secret=\"${google_default_client_secret}\""
+
+	local myarch="$(tc-arch)"
+
+	# Avoid CFLAGS problems, bug #352457, bug #390147.
+	if ! use custom-cflags; then
+		replace-flags "-Os" "-O2"
+		strip-flags
+
+		# Prevent linker from running out of address space, bug #471810 .
+		if use x86; then
+			filter-flags "-g*"
+		fi
+
+		# Prevent libvpx build failures. Bug 530248, 544702, 546984.
+		if [[ ${myarch} == amd64 || ${myarch} == x86 ]]; then
+			filter-flags -mno-mmx -mno-sse2 -mno-ssse3 -mno-sse4.1 -mno-avx -mno-avx2
+		fi
+	fi
+
+	if [[ $myarch = amd64 ]] ; then
+		myconf_gn+=" target_cpu=\"x64\""
+		ffmpeg_target_arch=x64
+	elif [[ $myarch = x86 ]] ; then
+		myconf_gn+=" target_cpu=\"x86\""
+		ffmpeg_target_arch=ia32
+
+		# This is normally defined by compiler_cpu_abi in
+		# build/config/compiler/BUILD.gn, but we patch that part out.
+		append-flags -msse2 -mfpmath=sse -mmmx
+	elif [[ $myarch = arm64 ]] ; then
+		myconf_gn+=" target_cpu=\"arm64\""
+		ffmpeg_target_arch=arm64
+	elif [[ $myarch = arm ]] ; then
+		myconf_gn+=" target_cpu=\"arm\""
+		ffmpeg_target_arch=$(usex neon arm-neon arm)
+	else
+		die "Failed to determine target arch, got '$myarch'."
+	fi
+
+	# Make sure that -Werror doesn't get added to CFLAGS by the build system.
+	# Depending on GCC version the warnings are different and we don't want
+	# the build to fail because of that.
+	myconf_gn+=" treat_warnings_as_errors=false"
+
+	# Disable fatal linker warnings, bug 506268.
+	myconf_gn+=" fatal_linker_warnings=false"
+
+	# musl does not support malloc interposition
+	if use elibc_musl; then
+        myconf_gn+=" use_allocator_shim=false"
+	fi
+
+	# Bug 491582.
+	export TMPDIR="${WORKDIR}/temp"
+	mkdir -p -m 755 "${TMPDIR}" || die
+
+	# https://bugs.gentoo.org/654216
+	addpredict /dev/dri/ #nowarn
+
+	#if ! use system-ffmpeg; then
+	if false; then
+		local build_ffmpeg_args=""
+		if use pic && [[ "${ffmpeg_target_arch}" == "ia32" ]]; then
+			build_ffmpeg_args+=" --disable-asm"
+		fi
+
+		# Re-configure bundled ffmpeg. See bug #491378 for example reasons.
+		einfo "Configuring bundled ffmpeg..."
+		pushd third_party/ffmpeg > /dev/null || die
+		chromium/scripts/build_ffmpeg.py linux ${ffmpeg_target_arch} \
+			--branding ${ffmpeg_branding} -- ${build_ffmpeg_args} || die
+		chromium/scripts/copy_config.sh || die
+		chromium/scripts/generate_gn.py || die
+		popd > /dev/null || die
+	fi
+
+	einfo "Configuring Chromium..."
+	set -- gn gen --args="${myconf_gn} ${EXTRA_GN}" out/Release
+	echo "$@"
+	"$@" || die
+}
+
+src_compile() {
+	# Final link uses lots of file descriptors.
+	ulimit -n 2048
+
+	# Calling this here supports resumption via FEATURES=keepwork
+	python_setup
+
+	#"${EPYTHON}" tools/clang/scripts/update.py --force-local-build --gcc-toolchain /usr --skip-checkout --use-system-cmake --without-android || die
+
+	# Build mksnapshot and pax-mark it.
+	local x
+	for x in mksnapshot v8_context_snapshot_generator; do
+		if tc-is-cross-compiler; then
+			eninja -C out/Release "host/${x}"
+			pax-mark m "out/Release/host/${x}"
+		else
+			eninja -C out/Release "${x}"
+			pax-mark m "out/Release/${x}"
+		fi
+	done
+
+	# Even though ninja autodetects number of CPUs, we respect
+	# user's options, for debugging with -j 1 or any other reason.
+	eninja -C out/Release chrome chromedriver
+	use suid && eninja -C out/Release chrome_sandbox
+
+	pax-mark m out/Release/chrome
+}
+
+src_install() {
+	local CHROMIUM_HOME="/usr/$(get_libdir)/chromium-browser"
+	exeinto "${CHROMIUM_HOME}"
+	doexe out/Release/chrome
+
+	if use suid; then
+		newexe out/Release/chrome_sandbox chrome-sandbox
+		fperms 4755 "${CHROMIUM_HOME}/chrome-sandbox"
+	fi
+
+	doexe out/Release/chromedriver
+
+	local sedargs=( -e "s:/usr/lib/:/usr/$(get_libdir)/:g" )
+	sed "${sedargs[@]}" "${FILESDIR}/chromium-launcher-r3.sh" > chromium-launcher.sh || die
+	doexe chromium-launcher.sh
+
+	# It is important that we name the target "chromium-browser",
+	# xdg-utils expect it; bug #355517.
+	dosym "${CHROMIUM_HOME}/chromium-launcher.sh" /usr/bin/chromium-browser
+	# keep the old symlink around for consistency
+	dosym "${CHROMIUM_HOME}/chromium-launcher.sh" /usr/bin/chromium
+
+	dosym "${CHROMIUM_HOME}/chromedriver" /usr/bin/chromedriver
+
+	# Allow users to override command-line options, bug #357629.
+	insinto /etc/chromium
+	newins "${FILESDIR}/chromium.default" "default"
+
+	pushd out/Release/locales > /dev/null || die
+	chromium_remove_language_paks
+	popd
+
+	insinto "${CHROMIUM_HOME}"
+	doins out/Release/*.bin
+	doins out/Release/*.pak
+	doins out/Release/*.so
+
+	if ! use system-icu; then
+		doins out/Release/icudtl.dat
+	fi
+
+	doins -r out/Release/locales
+	doins -r out/Release/resources
+
+	if [[ -d out/Release/swiftshader ]]; then
+		insinto "${CHROMIUM_HOME}/swiftshader"
+		doins out/Release/swiftshader/*.so
+	fi
+
+	# Install icons and desktop entry.
+	local branding size
+	for size in 16 22 24 32 48 64 128 256 ; do
+		case ${size} in
+			16|32) branding="chrome/app/theme/default_100_percent/chromium" ;;
+				*) branding="chrome/app/theme/chromium" ;;
+		esac
+		newicon -s ${size} "${branding}/product_logo_${size}.png" \
+			chromium-browser.png
+	done
+
+	local mime_types="text/html;text/xml;application/xhtml+xml;"
+	mime_types+="x-scheme-handler/http;x-scheme-handler/https;" # bug #360797
+	mime_types+="x-scheme-handler/ftp;" # bug #412185
+	mime_types+="x-scheme-handler/mailto;x-scheme-handler/webcal;" # bug #416393
+	make_desktop_entry \
+		chromium-browser \
+		"Chromium" \
+		chromium-browser \
+		"Network;WebBrowser" \
+		"MimeType=${mime_types}\nStartupWMClass=chromium-browser"
+	sed -e "/^Exec/s/$/ %U/" -i "${ED}"/usr/share/applications/*.desktop || die
+
+	# Install GNOME default application entry (bug #303100).
+	insinto /usr/share/gnome-control-center/default-apps
+	newins "${FILESDIR}"/chromium-browser.xml chromium-browser.xml
+
+	readme.gentoo_create_doc
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
+	xdg_desktop_database_update
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+	xdg_desktop_database_update
+	readme.gentoo_print_elog
+}

--- a/www-client/firefox/firefox-41.0.2-r99.ebuild
+++ b/www-client/firefox/firefox-41.0.2-r99.ebuild
@@ -1,0 +1,433 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+VIRTUALX_REQUIRED="pgo"
+WANT_AUTOCONF="2.1"
+MOZ_ESR=""
+
+# This list can be updated with scripts/get_langs.sh from the mozilla overlay
+# No official support as of fetch time
+# csb
+MOZ_LANGS=( af ar as ast be bg bn-BD bn-IN br bs ca cs cy da de el en
+en-GB en-US en-ZA eo es-AR es-CL es-ES es-MX et eu fa fi fr fy-NL ga-IE gd
+gl gu-IN he hi-IN hr hu hy-AM id is it ja kk km kn ko lt lv mai mk ml mr
+nb-NO nl nn-NO or pa-IN pl pt-BR pt-PT rm ro ru si sk sl son sq sr sv-SE ta te
+th tr uk vi xh zh-CN zh-TW )
+
+# Convert the ebuild version to the upstream mozilla version, used by mozlinguas
+MOZ_PV="${PV/_alpha/a}" # Handle alpha for SRC_URI
+MOZ_PV="${MOZ_PV/_beta/b}" # Handle beta for SRC_URI
+MOZ_PV="${MOZ_PV/_rc/rc}" # Handle rc for SRC_URI
+
+if [[ ${MOZ_ESR} == 1 ]]; then
+	# ESR releases have slightly version numbers
+	MOZ_PV="${MOZ_PV}esr"
+fi
+
+# Patch version
+PATCH="${PN}-41.0-patches-01"
+MOZ_HTTP_URI="http://archive.mozilla.org/pub/${PN}/releases"
+
+MOZCONFIG_OPTIONAL_WIFI=1
+MOZCONFIG_OPTIONAL_JIT="enabled"
+
+inherit check-reqs flag-o-matic toolchain-funcs eutils gnome2-utils mozconfig-v6.41 multilib pax-utils fdo-mime autotools virtualx mozlinguas
+
+DESCRIPTION="Firefox Web Browser"
+HOMEPAGE="http://www.mozilla.com/firefox"
+
+KEYWORDS="~amd64 ~arm ~ppc ~x86"
+
+SLOT="0"
+LICENSE="MPL-2.0 GPL-2 LGPL-2.1"
+IUSE="bindist egl hardened +minimal neon pgo selinux +gmp-autoupdate test"
+RESTRICT="!bindist? ( bindist )"
+
+# More URIs appended below...
+SRC_URI="${SRC_URI}
+	https://dev.gentoo.org/~anarchy/mozilla/patchsets/${PATCH}.tar.xz
+	https://dev.gentoo.org/~axs/mozilla/patchsets/${PATCH}.tar.xz
+	https://dev.gentoo.org/~polynomial-c/mozilla/patchsets/${PATCH}.tar.xz"
+
+ASM_DEPEND=">=dev-lang/yasm-1.1"
+
+# Mesa 7.10 needed for WebGL + bugfixes
+RDEPEND="
+	>=dev-libs/nss-3.19.2
+	>=dev-libs/nspr-4.10.8
+	selinux? ( sec-policy/selinux-mozilla )"
+
+DEPEND="${RDEPEND}
+	pgo? (
+		>=sys-devel/gcc-4.5 )
+	amd64? ( ${ASM_DEPEND}
+		virtual/opengl )
+	x86? ( ${ASM_DEPEND}
+		virtual/opengl )"
+
+# No source releases for alpha|beta
+if [[ ${PV} =~ alpha ]]; then
+	CHANGESET="8a3042764de7"
+	SRC_URI="${SRC_URI}
+		https://dev.gentoo.org/~nirbheek/mozilla/firefox/firefox-${MOZ_PV}_${CHANGESET}.source.tar.xz"
+	S="${WORKDIR}/mozilla-aurora-${CHANGESET}"
+elif [[ ${PV} =~ beta ]]; then
+	S="${WORKDIR}/mozilla-beta"
+	SRC_URI="${SRC_URI}
+		${MOZ_HTTP_URI}/${MOZ_PV}/source/firefox-${MOZ_PV}.source.tar.xz"
+else
+	SRC_URI="${SRC_URI}
+		${MOZ_HTTP_URI}/${MOZ_PV}/source/firefox-${MOZ_PV}.source.tar.xz"
+	if [[ ${MOZ_ESR} == 1 ]]; then
+		S="${WORKDIR}/mozilla-esr${PV%%.*}"
+	else
+		S="${WORKDIR}/mozilla-release"
+	fi
+fi
+
+QA_PRESTRIPPED="usr/$(get_libdir)/${PN}/firefox"
+
+BUILD_OBJ_DIR="${S}/ff"
+
+pkg_setup() {
+	moz_pkgsetup
+
+	# Avoid PGO profiling problems due to enviroment leakage
+	# These should *always* be cleaned up anyway
+	unset DBUS_SESSION_BUS_ADDRESS \
+		DISPLAY \
+		ORBIT_SOCKETDIR \
+		SESSION_MANAGER \
+		XDG_SESSION_COOKIE \
+		XAUTHORITY
+
+	if ! use bindist; then
+		einfo
+		elog "You are enabling official branding. You may not redistribute this build"
+		elog "to any users on your network or the internet. Doing so puts yourself into"
+		elog "a legal problem with Mozilla Foundation"
+		elog "You can disable it by emerging ${PN} _with_ the bindist USE-flag"
+	fi
+
+	if use pgo; then
+		einfo
+		ewarn "You will do a double build for profile guided optimization."
+		ewarn "This will result in your build taking at least twice as long as before."
+	fi
+}
+
+pkg_pretend() {
+	# Ensure we have enough disk space to compile
+	if use pgo || use debug || use test ; then
+		CHECKREQS_DISK_BUILD="8G"
+	else
+		CHECKREQS_DISK_BUILD="4G"
+	fi
+	check-reqs_pkg_setup
+}
+
+src_unpack() {
+	unpack ${A}
+
+	# Unpack language packs
+	mozlinguas_src_unpack
+}
+
+src_prepare() {
+	# Apply our patches
+	EPATCH_SUFFIX="patch" \
+	EPATCH_FORCE="yes" \
+	epatch "${WORKDIR}/firefox"
+
+	## patches for building with musl libc
+
+	#  already upstream
+	epatch "${FILESDIR}"/sandbox-cdefs.patch
+
+	#  with mozilla bug
+	epatch "${FILESDIR}"/basename.patch
+	epatch "${FILESDIR}"/updater.patch
+
+	#  others
+	epatch "${FILESDIR}"/crashreporter.patch
+	epatch "${FILESDIR}"/profiler-gettid.patch
+	epatch "${FILESDIR}"/skia.patch
+	epatch "${FILESDIR}"/fix-seccomp-bpf.patch
+
+	## end of musl patching
+
+	# Allow user to apply any additional patches without modifing ebuild
+	epatch_user
+
+	# Enable gnomebreakpad
+	if use debug ; then
+		sed -i -e "s:GNOME_DISABLE_CRASH_DIALOG=1:GNOME_DISABLE_CRASH_DIALOG=0:g" \
+			"${S}"/build/unix/run-mozilla.sh || die "sed failed!"
+	fi
+
+	# Ensure that our plugins dir is enabled as default
+	sed -i -e "s:/usr/lib/mozilla/plugins:/usr/lib/nsbrowser/plugins:" \
+		"${S}"/xpcom/io/nsAppFileLocationProvider.cpp || die "sed failed to replace plugin path for 32bit!"
+	sed -i -e "s:/usr/lib64/mozilla/plugins:/usr/lib64/nsbrowser/plugins:" \
+		"${S}"/xpcom/io/nsAppFileLocationProvider.cpp || die "sed failed to replace plugin path for 64bit!"
+
+	# Fix sandbox violations during make clean, bug 372817
+	sed -e "s:\(/no-such-file\):${T}\1:g" \
+		-i "${S}"/config/rules.mk \
+		-i "${S}"/nsprpub/configure{.in,} \
+		|| die
+
+	# Don't exit with error when some libs are missing which we have in
+	# system.
+	sed '/^MOZ_PKG_FATAL_WARNINGS/s@= 1@= 0@' \
+		-i "${S}"/browser/installer/Makefile.in || die
+
+	# Don't error out when there's no files to be removed:
+	sed 's@\(xargs rm\)$@\1 -f@' \
+		-i "${S}"/toolkit/mozapps/installer/packager.mk || die
+
+	# Keep codebase the same even if not using official branding
+	sed '/^MOZ_DEV_EDITION=1/d' \
+		-i "${S}"/browser/branding/aurora/configure.sh || die
+
+	eautoreconf
+
+	# Must run autoconf in js/src
+	cd "${S}"/js/src || die
+	eautoconf
+
+	# Need to update jemalloc's configure
+	cd "${S}"/memory/jemalloc/src || die
+	WANT_AUTOCONF= eautoconf
+}
+
+src_configure() {
+	MOZILLA_FIVE_HOME="/usr/$(get_libdir)/${PN}"
+	MEXTENSIONS="default"
+	# Google API keys (see http://www.chromium.org/developers/how-tos/api-keys)
+	# Note: These are for Gentoo Linux use ONLY. For your own distribution, please
+	# get your own set of keys.
+	_google_api_key=AIzaSyDEAOvatFo0eTgsV_ZlEzx0ObmepsMzfAc
+
+	####################################
+	#
+	# mozconfig, CFLAGS and CXXFLAGS setup
+	#
+	####################################
+
+	mozconfig_init
+	mozconfig_config
+
+	# It doesn't compile on alpha without this LDFLAGS
+	use alpha && append-ldflags "-Wl,--no-relax"
+
+	# Add full relro support for hardened
+	use hardened && append-ldflags "-Wl,-z,relro,-z,now"
+
+	if use neon ; then
+		mozconfig_annotate '' --with-fpu=neon
+		mozconfig_annotate '' --with-thumb=yes
+		mozconfig_annotate '' --with-thumb-interwork=no
+	fi
+
+	if [[ ${CHOST} == armv* ]] ; then
+		mozconfig_annotate '' --with-float-abi=hard
+		mozconfig_annotate '' --enable-skia
+
+		if ! use system-libvpx ; then
+			sed -i -e "s|softfp|hard|" \
+				"${S}"/media/libvpx/moz.build
+		fi
+	fi
+
+	use egl && mozconfig_annotate 'Enable EGL as GL provider' --with-gl-provider=EGL
+
+	# Setup api key for location services
+	echo -n "${_google_api_key}" > "${S}"/google-api-key
+	mozconfig_annotate '' --with-google-api-keyfile="${S}/google-api-key"
+
+	mozconfig_annotate '' --enable-extensions="${MEXTENSIONS}"
+	mozconfig_annotate '' --disable-mailnews
+
+	# Other ff-specific settings
+	mozconfig_annotate '' --with-default-mozilla-five-home=${MOZILLA_FIVE_HOME}
+
+	# Allow for a proper pgo build
+	if use pgo; then
+		echo "mk_add_options PROFILE_GEN_SCRIPT='\$(PYTHON) \$(OBJDIR)/_profile/pgo/profileserver.py'" >> "${S}"/.mozconfig
+	fi
+
+	echo "mk_add_options MOZ_OBJDIR=${BUILD_OBJ_DIR}" >> "${S}"/.mozconfig
+
+	# Finalize and report settings
+	mozconfig_final
+
+	if [[ $(gcc-major-version) -lt 4 ]]; then
+		append-cxxflags -fno-stack-protector
+	fi
+
+	# workaround for funky/broken upstream configure...
+	emake -f client.mk configure
+}
+
+src_compile() {
+	if use pgo; then
+		addpredict /root
+		addpredict /etc/gconf
+		# Reset and cleanup environment variables used by GNOME/XDG
+		gnome2_environment_reset
+
+		# Firefox tries to use dri stuff when it's run, see bug 380283
+		shopt -s nullglob
+		cards=$(echo -n /dev/dri/card* | sed 's/ /:/g')
+		if test -z "${cards}"; then
+			cards=$(echo -n /dev/ati/card* /dev/nvidiactl* | sed 's/ /:/g')
+			if test -n "${cards}"; then
+				# Binary drivers seem to cause access violations anyway, so
+				# let's use indirect rendering so that the device files aren't
+				# touched at all. See bug 394715.
+				export LIBGL_ALWAYS_INDIRECT=1
+			fi
+		fi
+		shopt -u nullglob
+		addpredict "${cards}"
+
+		CC="$(tc-getCC)" CXX="$(tc-getCXX)" LD="$(tc-getLD)" \
+		MOZ_MAKE_FLAGS="${MAKEOPTS}" SHELL="${SHELL:-${EPREFIX%/}/bin/bash}" \
+		Xemake -f client.mk profiledbuild || die "Xemake failed"
+	else
+		CC="$(tc-getCC)" CXX="$(tc-getCXX)" LD="$(tc-getLD)" \
+		MOZ_MAKE_FLAGS="${MAKEOPTS}" SHELL="${SHELL:-${EPREFIX%/}/bin/bash}" \
+		emake -f client.mk realbuild
+	fi
+
+}
+
+src_install() {
+	MOZILLA_FIVE_HOME="/usr/$(get_libdir)/${PN}"
+	DICTPATH="\"${EPREFIX}/usr/share/myspell\""
+
+	cd "${BUILD_OBJ_DIR}" || die
+
+	# Pax mark xpcshell for hardened support, only used for startupcache creation.
+	pax-mark m "${BUILD_OBJ_DIR}"/dist/bin/xpcshell
+
+	# Add our default prefs for firefox
+	cp "${FILESDIR}"/gentoo-default-prefs.js-1 \
+		"${BUILD_OBJ_DIR}/dist/bin/browser/defaults/preferences/all-gentoo.js" \
+		|| die
+
+	# Set default path to search for dictionaries.
+	echo "pref(\"spellchecker.dictionary_path\", ${DICTPATH});" \
+		>> "${BUILD_OBJ_DIR}/dist/bin/browser/defaults/preferences/all-gentoo.js" \
+		|| die
+
+	echo "pref(\"extensions.autoDisableScopes\", 3);" >> \
+		"${BUILD_OBJ_DIR}/dist/bin/browser/defaults/preferences/all-gentoo.js" \
+		|| die
+
+	local plugin
+	use gmp-autoupdate || for plugin in \
+	gmp-gmpopenh264 ; do
+		echo "pref(\"media.${plugin}.autoupdate\", false);" >> \
+			"${BUILD_OBJ_DIR}/dist/bin/browser/defaults/preferences/all-gentoo.js" \
+			|| die
+	done
+
+	MOZ_MAKE_FLAGS="${MAKEOPTS}" \
+	emake DESTDIR="${D}" install
+
+	# Install language packs
+	mozlinguas_src_install
+
+	local size sizes icon_path icon name
+	if use bindist; then
+		sizes="16 32 48"
+		icon_path="${S}/browser/branding/aurora"
+		# Firefox's new rapid release cycle means no more codenames
+		# Let's just stick with this one...
+		icon="aurora"
+		name="Aurora"
+
+		# Override preferences to set the MOZ_DEV_EDITION defaults, since we
+		# don't define MOZ_DEV_EDITION to avoid profile debaucles.
+		# (source: browser/app/profile/firefox.js)
+		cat >>"${BUILD_OBJ_DIR}/dist/bin/browser/defaults/preferences/all-gentoo.js" <<PROFILE_EOF
+pref("app.feedback.baseURL", "https://input.mozilla.org/%LOCALE%/feedback/firefoxdev/%VERSION%/");
+sticky_pref("lightweightThemes.selectedThemeID", "firefox-devedition@mozilla.org");
+sticky_pref("browser.devedition.theme.enabled", true);
+sticky_pref("devtools.theme", "dark");
+PROFILE_EOF
+
+	else
+		sizes="16 22 24 32 256"
+		icon_path="${S}/browser/branding/official"
+		icon="${PN}"
+		name="Mozilla Firefox"
+	fi
+
+	# Install icons and .desktop for menu entry
+	for size in ${sizes}; do
+		insinto "/usr/share/icons/hicolor/${size}x${size}/apps"
+		newins "${icon_path}/default${size}.png" "${icon}.png"
+	done
+	# The 128x128 icon has a different name
+	insinto "/usr/share/icons/hicolor/128x128/apps"
+	newins "${icon_path}/mozicon128.png" "${icon}.png"
+	# Install a 48x48 icon into /usr/share/pixmaps for legacy DEs
+	newicon "${icon_path}/content/icon48.png" "${icon}.png"
+	newmenu "${FILESDIR}/icon/${PN}.desktop" "${PN}.desktop"
+	sed -i -e "s:@NAME@:${name}:" -e "s:@ICON@:${icon}:" \
+		"${ED}/usr/share/applications/${PN}.desktop" || die
+
+	# Add StartupNotify=true bug 237317
+	if use startup-notification ; then
+		echo "StartupNotify=true"\
+			 >> "${ED}/usr/share/applications/${PN}.desktop" \
+			|| die
+	fi
+
+	# Required in order to use plugins and even run firefox on hardened.
+	if use jit; then
+		pax-mark m "${ED}"${MOZILLA_FIVE_HOME}/{firefox,firefox-bin,plugin-container}
+	else
+		pax-mark m "${ED}"${MOZILLA_FIVE_HOME}/plugin-container
+	fi
+
+	if use minimal; then
+		rm -r "${ED}"/usr/include "${ED}${MOZILLA_FIVE_HOME}"/{idl,include,lib,sdk} \
+			|| die "Failed to remove sdk and headers"
+	fi
+
+	# very ugly hack to make firefox not sigbus on sparc
+	# FIXME: is this still needed??
+	use sparc && { sed -e 's/Firefox/FirefoxGentoo/g' \
+					 -i "${ED}/${MOZILLA_FIVE_HOME}/application.ini" \
+					|| die "sparc sed failed"; }
+
+	# revdep-rebuild entry
+	insinto /etc/revdep-rebuild
+	echo "SEARCH_DIRS_MASK=${MOZILLA_FIVE_HOME}" >> ${T}/10firefox
+	doins "${T}"/10${PN} || die
+
+	# workaround to make firefox find libmozalloc.so on musl
+	into /
+	echo "LDPATH=${MOZILLA_FIVE_HOME}" > "${T}"/20firefox
+	doenvd "${T}"/20firefox || die
+}
+
+pkg_preinst() {
+	gnome2_icon_savelist
+}
+
+pkg_postinst() {
+	# Update mimedb for the new .desktop file
+	fdo-mime_desktop_database_update
+	gnome2_icon_cache_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+}


### PR DESCRIPTION
As discussed at https://github.com/gentoo/musl/issues/262 ,
these scripts can be added and then further updated.
The fact that the gentoo/musl overlay is missing these and other (very important) browsers is an issue that should be solved. This could be a first step to help achieve this. 