### PR TITLE
sys-libs/ldb: add missing include of fcntl.h

### DIFF
--- a/sys-libs/ldb/files/ldb-2.0.8-include-fcntl.h-for-pid_t.patch
+++ b/sys-libs/ldb/files/ldb-2.0.8-include-fcntl.h-for-pid_t.patch
@@ -1,0 +1,10 @@
+--- a/include/ldb.h
++++ b/include/ldb.h
+@@ -46,6 +46,7 @@
+ #define _LDB_H_ 1
+ /*! \endcond */
+ 
++#include <fcntl.h>
+ #include <stdbool.h>
+ #include <talloc.h>
+ #include <tevent.h>

--- a/sys-libs/ldb/ldb-2.0.8.ebuild
+++ b/sys-libs/ldb/ldb-2.0.8.ebuild
@@ -47,6 +47,7 @@ MULTILIB_WRAPPED_HEADERS=( /usr/include/pyldb.h )
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.5.2-optional_packages.patch
 	"${FILESDIR}"/${PN}-1.1.31-fix_PKGCONFIGDIR-when-python-disabled.patch
+	"${FILESDIR}"/${P}-include-fcntl.h-for-pid_t.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
Fixes #305.

Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>