### PR TITLE
sys-auth/polkit: add upstream fix for mozjs-68

### DIFF
--- a/sys-auth/polkit/files/polkit-0.116-make-netgroup-support-optional-2.patch
+++ b/sys-auth/polkit/files/polkit-0.116-make-netgroup-support-optional-2.patch
@@ -1,0 +1,219 @@
+diff --git a/configure.ac b/configure.ac
+index 4809dc9..d1ea325 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -100,7 +100,7 @@ AC_CHECK_LIB(expat,XML_ParserCreate,[EXPAT_LIBS="-lexpat"],
+ 	     [AC_MSG_ERROR([Can't find expat library. Please install expat.])])
+ AC_SUBST(EXPAT_LIBS)
+ 
+-AC_CHECK_FUNCS(clearenv fdatasync)
++AC_CHECK_FUNCS(clearenv fdatasync setnetgrent)
+ 
+ if test "x$GCC" = "xyes"; then
+   LDFLAGS="-Wl,--as-needed $LDFLAGS"
+diff --git a/src/polkit/polkitidentity.c b/src/polkit/polkitidentity.c
+index 3aa1f7f..793f17d 100644
+--- a/src/polkit/polkitidentity.c
++++ b/src/polkit/polkitidentity.c
+@@ -182,7 +182,15 @@ polkit_identity_from_string  (const gchar   *str,
+     }
+   else if (g_str_has_prefix (str, "unix-netgroup:"))
+     {
++#ifndef HAVE_SETNETGRENT
++      g_set_error (error,
++                   POLKIT_ERROR,
++                   POLKIT_ERROR_FAILED,
++                   "Netgroups are not available on this machine ('%s')",
++                   str);
++#else
+       identity = polkit_unix_netgroup_new (str + sizeof "unix-netgroup:" - 1);
++#endif
+     }
+ 
+   if (identity == NULL && (error != NULL && *error == NULL))
+@@ -344,6 +352,14 @@ polkit_identity_new_for_gvariant (GVariant  *variant,
+       GVariant *v;
+       const char *name;
+ 
++#ifndef HAVE_SETNETGRENT
++      g_set_error (error,
++                   POLKIT_ERROR,
++                   POLKIT_ERROR_FAILED,
++                   "Netgroups are not available on this machine");
++      goto out;
++#else
++
+       v = lookup_asv (details_gvariant, "name", G_VARIANT_TYPE_STRING, error);
+       if (v == NULL)
+         {
+@@ -353,6 +369,7 @@ polkit_identity_new_for_gvariant (GVariant  *variant,
+       name = g_variant_get_string (v, NULL);
+       ret = polkit_unix_netgroup_new (name);
+       g_variant_unref (v);
++#endif
+     }
+   else
+     {
+diff --git a/src/polkit/polkitunixnetgroup.c b/src/polkit/polkitunixnetgroup.c
+index 8a2b369..83f8d4a 100644
+--- a/src/polkit/polkitunixnetgroup.c
++++ b/src/polkit/polkitunixnetgroup.c
+@@ -194,6 +194,9 @@ polkit_unix_netgroup_set_name (PolkitUnixNetgroup *group,
+ PolkitIdentity *
+ polkit_unix_netgroup_new (const gchar *name)
+ {
++#ifndef HAVE_SETNETGRENT
++  g_assert_not_reached();
++#endif
+   g_return_val_if_fail (name != NULL, NULL);
+   return POLKIT_IDENTITY (g_object_new (POLKIT_TYPE_UNIX_NETGROUP,
+                                        "name", name,
+diff --git a/src/polkitbackend/polkitbackendinteractiveauthority.c b/src/polkitbackend/polkitbackendinteractiveauthority.c
+index 056d9a8..36c2f3d 100644
+--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
++++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
+@@ -2233,25 +2233,26 @@ get_users_in_net_group (PolkitIdentity                    *group,
+   GList *ret;
+ 
+   ret = NULL;
++#ifdef HAVE_SETNETGRENT
+   name = polkit_unix_netgroup_get_name (POLKIT_UNIX_NETGROUP (group));
+ 
+-#ifdef HAVE_SETNETGRENT_RETURN
++# ifdef HAVE_SETNETGRENT_RETURN
+   if (setnetgrent (name) == 0)
+     {
+       g_warning ("Error looking up net group with name %s: %s", name, g_strerror (errno));
+       goto out;
+     }
+-#else
++# else
+   setnetgrent (name);
+-#endif
++# endif /* HAVE_SETNETGRENT_RETURN */
+ 
+   for (;;)
+     {
+-#if defined(HAVE_NETBSD) || defined(HAVE_OPENBSD)
++# if defined(HAVE_NETBSD) || defined(HAVE_OPENBSD)
+       const char *hostname, *username, *domainname;
+-#else
++# else
+       char *hostname, *username, *domainname;
+-#endif
++# endif /* defined(HAVE_NETBSD) || defined(HAVE_OPENBSD) */
+       PolkitIdentity *user;
+       GError *error = NULL;
+ 
+@@ -2282,6 +2283,7 @@ get_users_in_net_group (PolkitIdentity                    *group,
+ 
+  out:
+   endnetgrent ();
++#endif /* HAVE_SETNETGRENT */
+   return ret;
+ }
+ 
+diff --git a/src/polkitbackend/polkitbackendjsauthority.cpp b/src/polkitbackend/polkitbackendjsauthority.cpp
+index 1d91103..366cbdf 100644
+--- a/src/polkitbackend/polkitbackendjsauthority.cpp
++++ b/src/polkitbackend/polkitbackendjsauthority.cpp
+@@ -1519,6 +1519,7 @@ js_polkit_user_is_in_netgroup (JSContext  *cx,
+ 
+   JS::CallArgs args = JS::CallArgsFromVp (argc, vp);
+ 
++#ifdef HAVE_SETNETGRENT
+   JS::RootedString usrstr (authority->priv->cx);
+   usrstr = args[0].toString();
+   user = JS_EncodeStringToUTF8 (cx, usrstr);
+@@ -1533,6 +1534,7 @@ js_polkit_user_is_in_netgroup (JSContext  *cx,
+     {
+       is_in_netgroup =  true;
+     }
++#endif
+ 
+   ret = true;
+ 
+diff --git a/test/polkit/polkitidentitytest.c b/test/polkit/polkitidentitytest.c
+index e91967b..e829aaa 100644
+--- a/test/polkit/polkitidentitytest.c
++++ b/test/polkit/polkitidentitytest.c
+@@ -19,6 +19,7 @@
+  * Author: Nikki VonHollen <vonhollen@google.com>
+  */
+ 
++#include "config.h"
+ #include "glib.h"
+ #include <polkit/polkit.h>
+ #include <polkit/polkitprivate.h>
+@@ -145,11 +146,15 @@ struct ComparisonTestData comparison_test_data [] = {
+   {"unix-group:root", "unix-group:jane", FALSE},
+   {"unix-group:jane", "unix-group:jane", TRUE},
+ 
++#ifdef HAVE_SETNETGRENT
+   {"unix-netgroup:foo", "unix-netgroup:foo", TRUE},
+   {"unix-netgroup:foo", "unix-netgroup:bar", FALSE},
++#endif
+ 
+   {"unix-user:root", "unix-group:root", FALSE},
++#ifdef HAVE_SETNETGRENT
+   {"unix-user:jane", "unix-netgroup:foo", FALSE},
++#endif
+ 
+   {NULL},
+ };
+@@ -181,11 +186,13 @@ main (int argc, char *argv[])
+   g_test_add_data_func ("/PolkitIdentity/group_string_2", "unix-group:jane", test_string);
+   g_test_add_data_func ("/PolkitIdentity/group_string_3", "unix-group:users", test_string);
+ 
++#ifdef HAVE_SETNETGRENT
+   g_test_add_data_func ("/PolkitIdentity/netgroup_string", "unix-netgroup:foo", test_string);
++  g_test_add_data_func ("/PolkitIdentity/netgroup_gvariant", "unix-netgroup:foo", test_gvariant);
++#endif
+ 
+   g_test_add_data_func ("/PolkitIdentity/user_gvariant", "unix-user:root", test_gvariant);
+   g_test_add_data_func ("/PolkitIdentity/group_gvariant", "unix-group:root", test_gvariant);
+-  g_test_add_data_func ("/PolkitIdentity/netgroup_gvariant", "unix-netgroup:foo", test_gvariant);
+ 
+   add_comparison_tests ();
+ 
+diff --git a/test/polkit/polkitunixnetgrouptest.c b/test/polkit/polkitunixnetgrouptest.c
+index 3701ba1..e3352eb 100644
+--- a/test/polkit/polkitunixnetgrouptest.c
++++ b/test/polkit/polkitunixnetgrouptest.c
+@@ -19,6 +19,7 @@
+  * Author: Nikki VonHollen <vonhollen@google.com>
+  */
+ 
++#include "config.h"
+ #include "glib.h"
+ #include <polkit/polkit.h>
+ #include <string.h>
+@@ -69,7 +70,9 @@ int
+ main (int argc, char *argv[])
+ {
+   g_test_init (&argc, &argv, NULL);
++#ifdef HAVE_SETNETGRENT
+   g_test_add_func ("/PolkitUnixNetgroup/new", test_new);
+   g_test_add_func ("/PolkitUnixNetgroup/set_name", test_set_name);
++#endif
+   return g_test_run ();
+ }
+diff --git a/test/polkitbackend/test-polkitbackendjsauthority.c b/test/polkitbackend/test-polkitbackendjsauthority.c
+index 71aad23..fdd28f3 100644
+--- a/test/polkitbackend/test-polkitbackendjsauthority.c
++++ b/test/polkitbackend/test-polkitbackendjsauthority.c
+@@ -137,12 +137,14 @@ test_get_admin_identities (void)
+         "unix-group:users"
+       }
+     },
++#ifdef HAVE_SETNETGRENT
+     {
+       "net.company.action3",
+       {
+         "unix-netgroup:foo"
+       }
+     },
++#endif
+   };
+   guint n;
+ 

--- a/sys-auth/polkit/files/polkit-0.116-spidermonkey-68.patch
+++ b/sys-auth/polkit/files/polkit-0.116-spidermonkey-68.patch
@@ -1,7 +1,7 @@
 From 12f3d25fb73c68151f84c97c79acab7d5344f606 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?X=E2=84=B9=20Ruoyao?= <xry111@mengyan1223.wang>
 Date: Fri, 13 Mar 2020 14:55:44 +0800
-Subject: [PATCH 1/3] Port JavaScript authority to mozjs-68
+Subject: [PATCH 1/5] Port JavaScript authority to mozjs-68
 
 ---
  configure.ac                                  |   2 +-
@@ -9,7 +9,7 @@ Subject: [PATCH 1/3] Port JavaScript authority to mozjs-68
  2 files changed, 76 insertions(+), 62 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index 5cedb4e..cd678f1 100644
+index 5cedb4ec..cd678f1c 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -79,7 +79,7 @@ PKG_CHECK_MODULES(GLIB, [gmodule-2.0 gio-unix-2.0 >= 2.30.0])
@@ -22,7 +22,7 @@ index 5cedb4e..cd678f1 100644
  AC_SUBST(LIBJS_CFLAGS)
  AC_SUBST(LIBJS_CXXFLAGS)
 diff --git a/src/polkitbackend/polkitbackendjsauthority.cpp b/src/polkitbackend/polkitbackendjsauthority.cpp
-index 0f18085..d5113cb 100644
+index 0f180856..d5113cb0 100644
 --- a/src/polkitbackend/polkitbackendjsauthority.cpp
 +++ b/src/polkitbackend/polkitbackendjsauthority.cpp
 @@ -43,7 +43,12 @@
@@ -391,22 +391,13 @@ index 0f18085..d5113cb 100644
  
    args.rval ().setBoolean (is_in_netgroup);
 -- 
-2.24.1
+GitLab
 
-
-From 2e6787ead894911e9172e873d15b84dc237ff209 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?X=E2=84=B9=20Ruoyao?= <xry111@mengyan1223.wang>
-Date: Fri, 13 Mar 2020 15:06:44 +0800
-Subject: [PATCH 2/3] ci: update to mozjs-68
-
----
- .gitlab-ci.yml | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
 
 From cf22af32577cf49b4e5ed9945ec9cca862c45b3e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?X=E2=84=B9=20Ruoyao?= <xry111@mengyan1223.wang>
 Date: Fri, 3 Apr 2020 23:47:38 +0800
-Subject: [PATCH 3/3] ensure to use C++14
+Subject: [PATCH 3/5] ensure to use C++14
 
 ---
  buildutil/ax_cxx_compile_stdcxx.m4 | 948 +++++++++++++++++++++++++++++
@@ -416,7 +407,7 @@ Subject: [PATCH 3/3] ensure to use C++14
 
 diff --git a/buildutil/ax_cxx_compile_stdcxx.m4 b/buildutil/ax_cxx_compile_stdcxx.m4
 new file mode 100644
-index 0000000..9e9eaed
+index 00000000..9e9eaeda
 --- /dev/null
 +++ b/buildutil/ax_cxx_compile_stdcxx.m4
 @@ -0,0 +1,948 @@
@@ -1369,7 +1360,7 @@ index 0000000..9e9eaed
 +
 +]])
 diff --git a/configure.ac b/configure.ac
-index cd678f1..3d50641 100644
+index cd678f1c..3d50641e 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -5,6 +5,7 @@ AC_INIT([polkit], [0.116], [http://lists.freedesktop.org/mailman/listinfo/polkit
@@ -1390,6 +1381,77 @@ index cd678f1..3d50641 100644
  # Taken from dbus
  AC_ARG_ENABLE(ansi,             [  --enable-ansi           enable -ansi -pedantic gcc flags],enable_ansi=$enableval,enable_ansi=no)
 -- 
-2.24.1
+GitLab
+
+
+From 14444004e60755d9aa362d30c8909460b8f9b824 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?X=E2=84=B9=20Ruoyao?= <xry111@mengyan1223.wang>
+Date: Mon, 8 Jun 2020 20:46:43 +0800
+Subject: [PATCH 4/5] remove an unused variable
+
+---
+ src/polkitbackend/polkitbackendjsauthority.cpp | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/src/polkitbackend/polkitbackendjsauthority.cpp b/src/polkitbackend/polkitbackendjsauthority.cpp
+index d5113cb0..61088a1d 100644
+--- a/src/polkitbackend/polkitbackendjsauthority.cpp
++++ b/src/polkitbackend/polkitbackendjsauthority.cpp
+@@ -470,7 +470,6 @@ static void
+ polkit_backend_js_authority_constructed (GObject *object)
+ {
+   PolkitBackendJsAuthority *authority = POLKIT_BACKEND_JS_AUTHORITY (object);
+-  gboolean entered_request = FALSE;
+ 
+   authority->priv->cx = JS_NewContext (8L * 1024L * 1024L);
+   if (authority->priv->cx == NULL)
+@@ -486,7 +485,6 @@ polkit_backend_js_authority_constructed (GObject *object)
+   JS::SetWarningReporter(authority->priv->cx, report_error);
+   JS_SetContextPrivate (authority->priv->cx, authority);
+ 
+-  entered_request = TRUE;
+ 
+   {
+     JS::RealmOptions compart_opts;
+@@ -552,7 +550,6 @@ polkit_backend_js_authority_constructed (GObject *object)
+     setup_file_monitors (authority);
+     load_scripts (authority);
+   }
+-  entered_request = FALSE;
+ 
+   G_OBJECT_CLASS (polkit_backend_js_authority_parent_class)->constructed (object);
+ 
+-- 
+GitLab
+
+
+From 3245061595a10644f8d32e48eeaaf6fbf0364c70 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?X=E2=84=B9=20Ruoyao?= <xry111@mengyan1223.wang>
+Date: Mon, 8 Jun 2020 21:25:33 +0800
+Subject: [PATCH 5/5] do not leak GFile
+
+---
+ src/polkitbackend/polkitbackendjsauthority.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/polkitbackend/polkitbackendjsauthority.cpp b/src/polkitbackend/polkitbackendjsauthority.cpp
+index 61088a1d..25bd1f93 100644
+--- a/src/polkitbackend/polkitbackendjsauthority.cpp
++++ b/src/polkitbackend/polkitbackendjsauthority.cpp
+@@ -311,8 +311,12 @@ load_scripts (PolkitBackendJsAuthority  *authority)
+           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                         "Error compiling script %s",
+                                         filename);
++          g_object_unref (file);
+           continue;
+         }
++
++      g_object_unref (file);
++
+       JS::SourceText<mozilla::Utf8Unit> source;
+       if (!source.init (authority->priv->cx, contents, len,
+                         JS::SourceOwnership::Borrowed))
+-- 
+GitLab
 
 

--- a/sys-auth/polkit/files/polkit-0.116-spidermonkey-68.patch
+++ b/sys-auth/polkit/files/polkit-0.116-spidermonkey-68.patch
@@ -1,0 +1,1395 @@
+From 12f3d25fb73c68151f84c97c79acab7d5344f606 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?X=E2=84=B9=20Ruoyao?= <xry111@mengyan1223.wang>
+Date: Fri, 13 Mar 2020 14:55:44 +0800
+Subject: [PATCH 1/3] Port JavaScript authority to mozjs-68
+
+---
+ configure.ac                                  |   2 +-
+ .../polkitbackendjsauthority.cpp              | 136 ++++++++++--------
+ 2 files changed, 76 insertions(+), 62 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 5cedb4e..cd678f1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -79,7 +79,7 @@ PKG_CHECK_MODULES(GLIB, [gmodule-2.0 gio-unix-2.0 >= 2.30.0])
+ AC_SUBST(GLIB_CFLAGS)
+ AC_SUBST(GLIB_LIBS)
+ 
+-PKG_CHECK_MODULES(LIBJS, [mozjs-60])
++PKG_CHECK_MODULES(LIBJS, [mozjs-68])
+ 
+ AC_SUBST(LIBJS_CFLAGS)
+ AC_SUBST(LIBJS_CXXFLAGS)
+diff --git a/src/polkitbackend/polkitbackendjsauthority.cpp b/src/polkitbackend/polkitbackendjsauthority.cpp
+index 0f18085..d5113cb 100644
+--- a/src/polkitbackend/polkitbackendjsauthority.cpp
++++ b/src/polkitbackend/polkitbackendjsauthority.cpp
+@@ -43,7 +43,12 @@
+ #include <systemd/sd-login.h>
+ #endif /* HAVE_LIBSYSTEMD */
+ 
++#include <js/CompilationAndEvaluation.h>
++#include <js/ContextOptions.h>
+ #include <js/Initialization.h>
++#include <js/Realm.h>
++#include <js/SourceText.h>
++#include <js/Warnings.h>
+ #include <jsapi.h>
+ 
+ #include "initjs.h" /* init.js */
+@@ -76,7 +81,7 @@ struct _PolkitBackendJsAuthorityPrivate
+ 
+   JSContext *cx;
+   JS::Heap<JSObject*> *js_global;
+-  JSAutoCompartment *ac;
++  JSAutoRealm *ac;
+   JS::Heap<JSObject*> *js_polkit;
+ 
+   GThread *runaway_killer_thread;
+@@ -298,14 +303,35 @@ load_scripts (PolkitBackendJsAuthority  *authority)
+   for (l = files; l != NULL; l = l->next)
+     {
+       const gchar *filename = (gchar *)l->data;
+-      JS::RootedScript script(authority->priv->cx);
++      GFile *file = g_file_new_for_path (filename);
++      char *contents;
++      gsize len;
++      if (!g_file_load_contents (file, NULL, &contents, &len, NULL, NULL))
++        {
++          polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
++                                        "Error compiling script %s",
++                                        filename);
++          continue;
++        }
++      JS::SourceText<mozilla::Utf8Unit> source;
++      if (!source.init (authority->priv->cx, contents, len,
++                        JS::SourceOwnership::Borrowed))
++        {
++          polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
++                                        "Error compiling script %s",
++                                        filename);
++          g_free (contents);
++          continue;
++        }
+       JS::CompileOptions options(authority->priv->cx);
+-      options.setUTF8(true);
+-      if (!JS::Compile (authority->priv->cx, options, filename, &script))
++      JS::RootedScript script(authority->priv->cx,
++                              JS::Compile (authority->priv->cx, options, source));
++      if (!script)
+         {
+           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                         "Error compiling script %s",
+                                         filename);
++          g_free (contents);
+           continue;
+         }
+ 
+@@ -318,11 +344,13 @@ load_scripts (PolkitBackendJsAuthority  *authority)
+           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                         "Error executing script %s",
+                                         filename);
++          g_free (contents);
+           continue;
+         }
+ 
+       //g_print ("Successfully loaded and evaluated script `%s'\n", filename);
+ 
++      g_free (contents);
+       num_scripts++;
+     }
+ 
+@@ -335,8 +363,6 @@ load_scripts (PolkitBackendJsAuthority  *authority)
+ static void
+ reload_scripts (PolkitBackendJsAuthority *authority)
+ {
+-  JS_BeginRequest (authority->priv->cx);
+-
+   JS::AutoValueArray<1> args(authority->priv->cx);
+   JS::RootedValue rval(authority->priv->cx);
+ 
+@@ -351,7 +377,7 @@ reload_scripts (PolkitBackendJsAuthority *authority)
+     {
+       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                     "Error deleting old rules, not loading new ones");
+-      goto out;
++      return;
+     }
+ 
+   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+@@ -362,8 +388,6 @@ reload_scripts (PolkitBackendJsAuthority *authority)
+ 
+   /* Let applications know we have new rules... */
+   g_signal_emit_by_name (authority, "changed");
+- out:
+-  JS_EndRequest (authority->priv->cx);
+ }
+ 
+ static void
+@@ -462,11 +486,10 @@ polkit_backend_js_authority_constructed (GObject *object)
+   JS::SetWarningReporter(authority->priv->cx, report_error);
+   JS_SetContextPrivate (authority->priv->cx, authority);
+ 
+-  JS_BeginRequest(authority->priv->cx);
+   entered_request = TRUE;
+ 
+   {
+-    JS::CompartmentOptions compart_opts;
++    JS::RealmOptions compart_opts;
+ 
+     JS::RootedObject global(authority->priv->cx);
+ 
+@@ -476,12 +499,12 @@ polkit_backend_js_authority_constructed (GObject *object)
+     if (!global)
+       goto fail;
+ 
+-    authority->priv->ac = new JSAutoCompartment(authority->priv->cx,  global);
++    authority->priv->ac = new JSAutoRealm(authority->priv->cx, global);
+ 
+     if (!authority->priv->ac)
+       goto fail;
+ 
+-    if (!JS_InitStandardClasses (authority->priv->cx, global))
++    if (!JS::InitRealmStandardClasses (authority->priv->cx))
+       goto fail;
+ 
+     JS::RootedObject polkit(authority->priv->cx);
+@@ -503,13 +526,13 @@ polkit_backend_js_authority_constructed (GObject *object)
+ 
+     JS::CompileOptions options(authority->priv->cx);
+     JS::RootedValue rval(authority->priv->cx);
+-    if (!JS::Evaluate (authority->priv->cx,
+-                       options,
+-                       init_js, strlen (init_js), /* init.js */
+-                       &rval)) /* rval */
+-      {
+-        goto fail;
+-      }
++    JS::SourceText<mozilla::Utf8Unit> source;
++    if (!source.init (authority->priv->cx, init_js, strlen (init_js),
++                      JS::SourceOwnership::Borrowed))
++      goto fail;
++
++    if (!JS::Evaluate (authority->priv->cx, options, source, &rval))
++      goto fail;
+ 
+     if (authority->priv->rules_dirs == NULL)
+       {
+@@ -529,7 +552,6 @@ polkit_backend_js_authority_constructed (GObject *object)
+     setup_file_monitors (authority);
+     load_scripts (authority);
+   }
+-  JS_EndRequest (authority->priv->cx);
+   entered_request = FALSE;
+ 
+   G_OBJECT_CLASS (polkit_backend_js_authority_parent_class)->constructed (object);
+@@ -537,8 +559,6 @@ polkit_backend_js_authority_constructed (GObject *object)
+   return;
+ 
+  fail:
+-  if (entered_request)
+-    JS_EndRequest (authority->priv->cx);
+   g_critical ("Error initializing JavaScript environment");
+   g_assert_not_reached ();
+ }
+@@ -680,7 +700,7 @@ set_property_strv (PolkitBackendJsAuthority  *authority,
+                    GPtrArray                 *value)
+ {
+   JS::RootedValue value_jsval(authority->priv->cx);
+-  JS::AutoValueVector elems(authority->priv->cx);
++  JS::RootedValueVector elems(authority->priv->cx);
+   guint n;
+ 
+   if (!elems.resize(value->len))
+@@ -755,10 +775,15 @@ subject_to_jsval (PolkitBackendJsAuthority  *authority,
+   JS::RootedObject global(authority->priv->cx, authority->priv->js_global->get ());
+ 
+   src = "new Subject();";
+-  if (!JS::Evaluate (authority->priv->cx,
+-                     options,
+-                     src, strlen (src),
+-                     out_jsval))
++  JS::SourceText<mozilla::Utf8Unit> source;
++  if (!source.init (authority->priv->cx, src, strlen (src),
++                    JS::SourceOwnership::Borrowed))
++  {
++      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Evaluating '%s' failed", src);
++      goto out;
++  }
++
++  if (!JS::Evaluate (authority->priv->cx, options, source, out_jsval))
+     {
+       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Evaluating '%s' failed", src);
+       goto out;
+@@ -877,11 +902,15 @@ action_and_details_to_jsval (PolkitBackendJsAuthority  *authority,
+   JS::RootedObject global(authority->priv->cx, authority->priv->js_global->get ());
+ 
+   src = "new Action();";
++  JS::SourceText<mozilla::Utf8Unit> source;
++  if (!source.init (authority->priv->cx, src, strlen (src),
++                    JS::SourceOwnership::Borrowed))
++  {
++      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Evaluating '%s' failed", src);
++      goto out;
++  }
+ 
+-  if (!JS::Evaluate (authority->priv->cx,
+-                     options,
+-                     src, strlen (src),
+-                     out_jsval))
++  if (!JS::Evaluate (authority->priv->cx, options, source, out_jsval))
+     {
+       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Evaluating '%s' failed", src);
+       goto out;
+@@ -1089,11 +1118,9 @@ polkit_backend_js_authority_get_admin_auth_identities (PolkitBackendInteractiveA
+   guint n;
+   GError *error = NULL;
+   JS::RootedString ret_jsstr (authority->priv->cx);
+-  gchar *ret_str = NULL;
++  JS::UniqueChars ret_str;
+   gchar **ret_strs = NULL;
+ 
+-  JS_BeginRequest (authority->priv->cx);
+-
+   if (!action_and_details_to_jsval (authority, action_id, details, args[0], &error))
+     {
+       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+@@ -1142,7 +1169,7 @@ polkit_backend_js_authority_get_admin_auth_identities (PolkitBackendInteractiveA
+       goto out;
+     }
+ 
+-  ret_strs = g_strsplit (ret_str, ",", -1);
++  ret_strs = g_strsplit (ret_str.get(), ",", -1);
+   for (n = 0; ret_strs != NULL && ret_strs[n] != NULL; n++)
+     {
+       const gchar *identity_str = ret_strs[n];
+@@ -1166,15 +1193,12 @@ polkit_backend_js_authority_get_admin_auth_identities (PolkitBackendInteractiveA
+ 
+  out:
+   g_strfreev (ret_strs);
+-  g_free (ret_str);
+   /* fallback to root password auth */
+   if (ret == NULL)
+     ret = g_list_prepend (ret, polkit_unix_user_new (0));
+ 
+   JS_MaybeGC (authority->priv->cx);
+ 
+-  JS_EndRequest (authority->priv->cx);
+-
+   return ret;
+ }
+ 
+@@ -1197,11 +1221,9 @@ polkit_backend_js_authority_check_authorization_sync (PolkitBackendInteractiveAu
+   JS::RootedValue rval(authority->priv->cx);
+   GError *error = NULL;
+   JS::RootedString ret_jsstr (authority->priv->cx);
+-  gchar *ret_str = NULL;
++  JS::UniqueChars ret_str;
+   gboolean good = FALSE;
+ 
+-  JS_BeginRequest (authority->priv->cx);
+-
+   if (!action_and_details_to_jsval (authority, action_id, details, args[0], &error))
+     {
+       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+@@ -1257,12 +1279,12 @@ polkit_backend_js_authority_check_authorization_sync (PolkitBackendInteractiveAu
+       goto out;
+     }
+ 
+-  g_strstrip (ret_str);
+-  if (!polkit_implicit_authorization_from_string (ret_str, &ret))
++  g_strstrip (ret_str.get());
++  if (!polkit_implicit_authorization_from_string (ret_str.get(), &ret))
+     {
+       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                     "Returned result `%s' is not valid",
+-                                    ret_str);
++                                    ret_str.get());
+       goto out;
+     }
+ 
+@@ -1271,12 +1293,9 @@ polkit_backend_js_authority_check_authorization_sync (PolkitBackendInteractiveAu
+  out:
+   if (!good)
+     ret = POLKIT_IMPLICIT_AUTHORIZATION_NOT_AUTHORIZED;
+-  g_free (ret_str);
+ 
+   JS_MaybeGC (authority->priv->cx);
+ 
+-  JS_EndRequest (authority->priv->cx);
+-
+   return ret;
+ }
+ 
+@@ -1289,15 +1308,14 @@ js_polkit_log (JSContext  *cx,
+ {
+   PolkitBackendJsAuthority *authority = POLKIT_BACKEND_JS_AUTHORITY (JS_GetContextPrivate (cx));
+   bool ret = false;
+-  char *s;
++  JS::UniqueChars s;
+ 
+   JS::CallArgs args = JS::CallArgsFromVp (argc, vp);
+ 
+   JS::RootedString jsstr (authority->priv->cx);
+   jsstr = args[0].toString ();
+   s = JS_EncodeStringToUTF8 (cx, jsstr);
+-  JS_ReportWarningUTF8 (cx, "%s", s);
+-  JS_free (cx, s);
++  JS::WarnUTF8 (cx, "%s", s.get());
+ 
+   ret = true;
+ 
+@@ -1400,7 +1418,7 @@ js_polkit_spawn (JSContext  *cx,
+   for (n = 0; n < array_len; n++)
+     {
+       JS::RootedValue elem_val(cx);
+-      char *s;
++      JS::UniqueChars s;
+ 
+       if (!JS_GetElement (cx, array_object, n, &elem_val))
+         {
+@@ -1415,8 +1433,7 @@ js_polkit_spawn (JSContext  *cx,
+       JS::RootedString jsstr (authority->priv->cx);
+       jsstr = elem_val.toString();
+       s = JS_EncodeStringToUTF8 (cx, jsstr);
+-      argv[n] = g_strdup (s);
+-      JS_free (cx, s);
++      argv[n] = g_strdup (s.get());
+     }
+ 
+   context = g_main_context_new ();
+@@ -1499,8 +1516,8 @@ js_polkit_user_is_in_netgroup (JSContext  *cx,
+ {
+   PolkitBackendJsAuthority *authority = POLKIT_BACKEND_JS_AUTHORITY (JS_GetContextPrivate (cx));
+   bool ret = false;
+-  char *user;
+-  char *netgroup;
++  JS::UniqueChars user;
++  JS::UniqueChars netgroup;
+   bool is_in_netgroup = false;
+ 
+   JS::CallArgs args = JS::CallArgsFromVp (argc, vp);
+@@ -1512,17 +1529,14 @@ js_polkit_user_is_in_netgroup (JSContext  *cx,
+   netgstr = args[1].toString();
+   netgroup = JS_EncodeStringToUTF8 (cx, netgstr);
+ 
+-  if (innetgr (netgroup,
++  if (innetgr (netgroup.get(),
+                NULL,  /* host */
+-               user,
++               user.get(),
+                NULL)) /* domain */
+     {
+       is_in_netgroup =  true;
+     }
+ 
+-  JS_free (cx, netgroup);
+-  JS_free (cx, user);
+-
+   ret = true;
+ 
+   args.rval ().setBoolean (is_in_netgroup);
+-- 
+2.24.1
+
+
+From 2e6787ead894911e9172e873d15b84dc237ff209 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?X=E2=84=B9=20Ruoyao?= <xry111@mengyan1223.wang>
+Date: Fri, 13 Mar 2020 15:06:44 +0800
+Subject: [PATCH 2/3] ci: update to mozjs-68
+
+---
+ .gitlab-ci.yml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+From cf22af32577cf49b4e5ed9945ec9cca862c45b3e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?X=E2=84=B9=20Ruoyao?= <xry111@mengyan1223.wang>
+Date: Fri, 3 Apr 2020 23:47:38 +0800
+Subject: [PATCH 3/3] ensure to use C++14
+
+---
+ buildutil/ax_cxx_compile_stdcxx.m4 | 948 +++++++++++++++++++++++++++++
+ configure.ac                       |   3 +-
+ 2 files changed, 950 insertions(+), 1 deletion(-)
+ create mode 100644 buildutil/ax_cxx_compile_stdcxx.m4
+
+diff --git a/buildutil/ax_cxx_compile_stdcxx.m4 b/buildutil/ax_cxx_compile_stdcxx.m4
+new file mode 100644
+index 0000000..9e9eaed
+--- /dev/null
++++ b/buildutil/ax_cxx_compile_stdcxx.m4
+@@ -0,0 +1,948 @@
++# ===========================================================================
++#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
++# ===========================================================================
++#
++# SYNOPSIS
++#
++#   AX_CXX_COMPILE_STDCXX(VERSION, [ext|noext], [mandatory|optional])
++#
++# DESCRIPTION
++#
++#   Check for baseline language coverage in the compiler for the specified
++#   version of the C++ standard.  If necessary, add switches to CXX and
++#   CXXCPP to enable support.  VERSION may be '11' (for the C++11 standard)
++#   or '14' (for the C++14 standard).
++#
++#   The second argument, if specified, indicates whether you insist on an
++#   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
++#   -std=c++11).  If neither is specified, you get whatever works, with
++#   preference for an extended mode.
++#
++#   The third argument, if specified 'mandatory' or if left unspecified,
++#   indicates that baseline support for the specified C++ standard is
++#   required and that the macro should error out if no mode with that
++#   support is found.  If specified 'optional', then configuration proceeds
++#   regardless, after defining HAVE_CXX${VERSION} if and only if a
++#   supporting mode is found.
++#
++# LICENSE
++#
++#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
++#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
++#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
++#   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
++#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
++#   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
++#   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
++#
++#   Copying and distribution of this file, with or without modification, are
++#   permitted in any medium without royalty provided the copyright notice
++#   and this notice are preserved.  This file is offered as-is, without any
++#   warranty.
++
++#serial 10
++
++dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
++dnl  (serial version number 13).
++
++AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
++  m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
++        [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
++        [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
++        [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
++  m4_if([$2], [], [],
++        [$2], [ext], [],
++        [$2], [noext], [],
++        [m4_fatal([invalid second argument `$2' to AX_CXX_COMPILE_STDCXX])])dnl
++  m4_if([$3], [], [ax_cxx_compile_cxx$1_required=true],
++        [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
++        [$3], [optional], [ax_cxx_compile_cxx$1_required=false],
++        [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
++  AC_LANG_PUSH([C++])dnl
++  ac_success=no
++
++  m4_if([$2], [noext], [], [dnl
++  if test x$ac_success = xno; then
++    for alternative in ${ax_cxx_compile_alternatives}; do
++      switch="-std=gnu++${alternative}"
++      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
++      AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
++                     $cachevar,
++        [ac_save_CXX="$CXX"
++         CXX="$CXX $switch"
++         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
++          [eval $cachevar=yes],
++          [eval $cachevar=no])
++         CXX="$ac_save_CXX"])
++      if eval test x\$$cachevar = xyes; then
++        CXX="$CXX $switch"
++        if test -n "$CXXCPP" ; then
++          CXXCPP="$CXXCPP $switch"
++        fi
++        ac_success=yes
++        break
++      fi
++    done
++  fi])
++
++  m4_if([$2], [ext], [], [dnl
++  if test x$ac_success = xno; then
++    dnl HP's aCC needs +std=c++11 according to:
++    dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
++    dnl Cray's crayCC needs "-h std=c++11"
++    for alternative in ${ax_cxx_compile_alternatives}; do
++      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}"; do
++        cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
++        AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
++                       $cachevar,
++          [ac_save_CXX="$CXX"
++           CXX="$CXX $switch"
++           AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
++            [eval $cachevar=yes],
++            [eval $cachevar=no])
++           CXX="$ac_save_CXX"])
++        if eval test x\$$cachevar = xyes; then
++          CXX="$CXX $switch"
++          if test -n "$CXXCPP" ; then
++            CXXCPP="$CXXCPP $switch"
++          fi
++          ac_success=yes
++          break
++        fi
++      done
++      if test x$ac_success = xyes; then
++        break
++      fi
++    done
++  fi])
++  AC_LANG_POP([C++])
++  if test x$ax_cxx_compile_cxx$1_required = xtrue; then
++    if test x$ac_success = xno; then
++      AC_MSG_ERROR([*** A compiler with support for C++$1 language features is required.])
++    fi
++  fi
++  if test x$ac_success = xno; then
++    HAVE_CXX$1=0
++    AC_MSG_NOTICE([No compiler with C++$1 support was found])
++  else
++    HAVE_CXX$1=1
++    AC_DEFINE(HAVE_CXX$1,1,
++              [define if the compiler supports basic C++$1 syntax])
++  fi
++  AC_SUBST(HAVE_CXX$1)
++])
++
++
++dnl  Test body for checking C++11 support
++
++m4_define([_AX_CXX_COMPILE_STDCXX_testbody_11],
++  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
++)
++
++
++dnl  Test body for checking C++14 support
++
++m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
++  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
++  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
++)
++
++m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
++  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
++  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
++  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
++)
++
++dnl  Tests for new features in C++11
++
++m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_11], [[
++
++// If the compiler admits that it is not ready for C++11, why torture it?
++// Hopefully, this will speed up the test.
++
++#ifndef __cplusplus
++
++#error "This is not a C++ compiler"
++
++#elif __cplusplus < 201103L
++
++#error "This is not a C++11 compiler"
++
++#else
++
++namespace cxx11
++{
++
++  namespace test_static_assert
++  {
++
++    template <typename T>
++    struct check
++    {
++      static_assert(sizeof(int) <= sizeof(T), "not big enough");
++    };
++
++  }
++
++  namespace test_final_override
++  {
++
++    struct Base
++    {
++      virtual void f() {}
++    };
++
++    struct Derived : public Base
++    {
++      virtual void f() override {}
++    };
++
++  }
++
++  namespace test_double_right_angle_brackets
++  {
++
++    template < typename T >
++    struct check {};
++
++    typedef check<void> single_type;
++    typedef check<check<void>> double_type;
++    typedef check<check<check<void>>> triple_type;
++    typedef check<check<check<check<void>>>> quadruple_type;
++
++  }
++
++  namespace test_decltype
++  {
++
++    int
++    f()
++    {
++      int a = 1;
++      decltype(a) b = 2;
++      return a + b;
++    }
++
++  }
++
++  namespace test_type_deduction
++  {
++
++    template < typename T1, typename T2 >
++    struct is_same
++    {
++      static const bool value = false;
++    };
++
++    template < typename T >
++    struct is_same<T, T>
++    {
++      static const bool value = true;
++    };
++
++    template < typename T1, typename T2 >
++    auto
++    add(T1 a1, T2 a2) -> decltype(a1 + a2)
++    {
++      return a1 + a2;
++    }
++
++    int
++    test(const int c, volatile int v)
++    {
++      static_assert(is_same<int, decltype(0)>::value == true, "");
++      static_assert(is_same<int, decltype(c)>::value == false, "");
++      static_assert(is_same<int, decltype(v)>::value == false, "");
++      auto ac = c;
++      auto av = v;
++      auto sumi = ac + av + 'x';
++      auto sumf = ac + av + 1.0;
++      static_assert(is_same<int, decltype(ac)>::value == true, "");
++      static_assert(is_same<int, decltype(av)>::value == true, "");
++      static_assert(is_same<int, decltype(sumi)>::value == true, "");
++      static_assert(is_same<int, decltype(sumf)>::value == false, "");
++      static_assert(is_same<int, decltype(add(c, v))>::value == true, "");
++      return (sumf > 0.0) ? sumi : add(c, v);
++    }
++
++  }
++
++  namespace test_noexcept
++  {
++
++    int f() { return 0; }
++    int g() noexcept { return 0; }
++
++    static_assert(noexcept(f()) == false, "");
++    static_assert(noexcept(g()) == true, "");
++
++  }
++
++  namespace test_constexpr
++  {
++
++    template < typename CharT >
++    unsigned long constexpr
++    strlen_c_r(const CharT *const s, const unsigned long acc) noexcept
++    {
++      return *s ? strlen_c_r(s + 1, acc + 1) : acc;
++    }
++
++    template < typename CharT >
++    unsigned long constexpr
++    strlen_c(const CharT *const s) noexcept
++    {
++      return strlen_c_r(s, 0UL);
++    }
++
++    static_assert(strlen_c("") == 0UL, "");
++    static_assert(strlen_c("1") == 1UL, "");
++    static_assert(strlen_c("example") == 7UL, "");
++    static_assert(strlen_c("another\0example") == 7UL, "");
++
++  }
++
++  namespace test_rvalue_references
++  {
++
++    template < int N >
++    struct answer
++    {
++      static constexpr int value = N;
++    };
++
++    answer<1> f(int&)       { return answer<1>(); }
++    answer<2> f(const int&) { return answer<2>(); }
++    answer<3> f(int&&)      { return answer<3>(); }
++
++    void
++    test()
++    {
++      int i = 0;
++      const int c = 0;
++      static_assert(decltype(f(i))::value == 1, "");
++      static_assert(decltype(f(c))::value == 2, "");
++      static_assert(decltype(f(0))::value == 3, "");
++    }
++
++  }
++
++  namespace test_uniform_initialization
++  {
++
++    struct test
++    {
++      static const int zero {};
++      static const int one {1};
++    };
++
++    static_assert(test::zero == 0, "");
++    static_assert(test::one == 1, "");
++
++  }
++
++  namespace test_lambdas
++  {
++
++    void
++    test1()
++    {
++      auto lambda1 = [](){};
++      auto lambda2 = lambda1;
++      lambda1();
++      lambda2();
++    }
++
++    int
++    test2()
++    {
++      auto a = [](int i, int j){ return i + j; }(1, 2);
++      auto b = []() -> int { return '0'; }();
++      auto c = [=](){ return a + b; }();
++      auto d = [&](){ return c; }();
++      auto e = [a, &b](int x) mutable {
++        const auto identity = [](int y){ return y; };
++        for (auto i = 0; i < a; ++i)
++          a += b--;
++        return x + identity(a + b);
++      }(0);
++      return a + b + c + d + e;
++    }
++
++    int
++    test3()
++    {
++      const auto nullary = [](){ return 0; };
++      const auto unary = [](int x){ return x; };
++      using nullary_t = decltype(nullary);
++      using unary_t = decltype(unary);
++      const auto higher1st = [](nullary_t f){ return f(); };
++      const auto higher2nd = [unary](nullary_t f1){
++        return [unary, f1](unary_t f2){ return f2(unary(f1())); };
++      };
++      return higher1st(nullary) + higher2nd(nullary)(unary);
++    }
++
++  }
++
++  namespace test_variadic_templates
++  {
++
++    template <int...>
++    struct sum;
++
++    template <int N0, int... N1toN>
++    struct sum<N0, N1toN...>
++    {
++      static constexpr auto value = N0 + sum<N1toN...>::value;
++    };
++
++    template <>
++    struct sum<>
++    {
++      static constexpr auto value = 0;
++    };
++
++    static_assert(sum<>::value == 0, "");
++    static_assert(sum<1>::value == 1, "");
++    static_assert(sum<23>::value == 23, "");
++    static_assert(sum<1, 2>::value == 3, "");
++    static_assert(sum<5, 5, 11>::value == 21, "");
++    static_assert(sum<2, 3, 5, 7, 11, 13>::value == 41, "");
++
++  }
++
++  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
++  // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
++  // because of this.
++  namespace test_template_alias_sfinae
++  {
++
++    struct foo {};
++
++    template<typename T>
++    using member = typename T::member_type;
++
++    template<typename T>
++    void func(...) {}
++
++    template<typename T>
++    void func(member<T>*) {}
++
++    void test();
++
++    void test() { func<foo>(0); }
++
++  }
++
++}  // namespace cxx11
++
++#endif  // __cplusplus >= 201103L
++
++]])
++
++
++dnl  Tests for new features in C++14
++
++m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_14], [[
++
++// If the compiler admits that it is not ready for C++14, why torture it?
++// Hopefully, this will speed up the test.
++
++#ifndef __cplusplus
++
++#error "This is not a C++ compiler"
++
++#elif __cplusplus < 201402L
++
++#error "This is not a C++14 compiler"
++
++#else
++
++namespace cxx14
++{
++
++  namespace test_polymorphic_lambdas
++  {
++
++    int
++    test()
++    {
++      const auto lambda = [](auto&&... args){
++        const auto istiny = [](auto x){
++          return (sizeof(x) == 1UL) ? 1 : 0;
++        };
++        const int aretiny[] = { istiny(args)... };
++        return aretiny[0];
++      };
++      return lambda(1, 1L, 1.0f, '1');
++    }
++
++  }
++
++  namespace test_binary_literals
++  {
++
++    constexpr auto ivii = 0b0000000000101010;
++    static_assert(ivii == 42, "wrong value");
++
++  }
++
++  namespace test_generalized_constexpr
++  {
++
++    template < typename CharT >
++    constexpr unsigned long
++    strlen_c(const CharT *const s) noexcept
++    {
++      auto length = 0UL;
++      for (auto p = s; *p; ++p)
++        ++length;
++      return length;
++    }
++
++    static_assert(strlen_c("") == 0UL, "");
++    static_assert(strlen_c("x") == 1UL, "");
++    static_assert(strlen_c("test") == 4UL, "");
++    static_assert(strlen_c("another\0test") == 7UL, "");
++
++  }
++
++  namespace test_lambda_init_capture
++  {
++
++    int
++    test()
++    {
++      auto x = 0;
++      const auto lambda1 = [a = x](int b){ return a + b; };
++      const auto lambda2 = [a = lambda1(x)](){ return a; };
++      return lambda2();
++    }
++
++  }
++
++  namespace test_digit_separators
++  {
++
++    constexpr auto ten_million = 100'000'000;
++    static_assert(ten_million == 100000000, "");
++
++  }
++
++  namespace test_return_type_deduction
++  {
++
++    auto f(int& x) { return x; }
++    decltype(auto) g(int& x) { return x; }
++
++    template < typename T1, typename T2 >
++    struct is_same
++    {
++      static constexpr auto value = false;
++    };
++
++    template < typename T >
++    struct is_same<T, T>
++    {
++      static constexpr auto value = true;
++    };
++
++    int
++    test()
++    {
++      auto x = 0;
++      static_assert(is_same<int, decltype(f(x))>::value, "");
++      static_assert(is_same<int&, decltype(g(x))>::value, "");
++      return x;
++    }
++
++  }
++
++}  // namespace cxx14
++
++#endif  // __cplusplus >= 201402L
++
++]])
++
++
++dnl  Tests for new features in C++17
++
++m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
++
++// If the compiler admits that it is not ready for C++17, why torture it?
++// Hopefully, this will speed up the test.
++
++#ifndef __cplusplus
++
++#error "This is not a C++ compiler"
++
++#elif __cplusplus < 201703L
++
++#error "This is not a C++17 compiler"
++
++#else
++
++#include <initializer_list>
++#include <utility>
++#include <type_traits>
++
++namespace cxx17
++{
++
++  namespace test_constexpr_lambdas
++  {
++
++    constexpr int foo = [](){return 42;}();
++
++  }
++
++  namespace test::nested_namespace::definitions
++  {
++
++  }
++
++  namespace test_fold_expression
++  {
++
++    template<typename... Args>
++    int multiply(Args... args)
++    {
++      return (args * ... * 1);
++    }
++
++    template<typename... Args>
++    bool all(Args... args)
++    {
++      return (args && ...);
++    }
++
++  }
++
++  namespace test_extended_static_assert
++  {
++
++    static_assert (true);
++
++  }
++
++  namespace test_auto_brace_init_list
++  {
++
++    auto foo = {5};
++    auto bar {5};
++
++    static_assert(std::is_same<std::initializer_list<int>, decltype(foo)>::value);
++    static_assert(std::is_same<int, decltype(bar)>::value);
++  }
++
++  namespace test_typename_in_template_template_parameter
++  {
++
++    template<template<typename> typename X> struct D;
++
++  }
++
++  namespace test_fallthrough_nodiscard_maybe_unused_attributes
++  {
++
++    int f1()
++    {
++      return 42;
++    }
++
++    [[nodiscard]] int f2()
++    {
++      [[maybe_unused]] auto unused = f1();
++
++      switch (f1())
++      {
++      case 17:
++        f1();
++        [[fallthrough]];
++      case 42:
++        f1();
++      }
++      return f1();
++    }
++
++  }
++
++  namespace test_extended_aggregate_initialization
++  {
++
++    struct base1
++    {
++      int b1, b2 = 42;
++    };
++
++    struct base2
++    {
++      base2() {
++        b3 = 42;
++      }
++      int b3;
++    };
++
++    struct derived : base1, base2
++    {
++        int d;
++    };
++
++    derived d1 {{1, 2}, {}, 4};  // full initialization
++    derived d2 {{}, {}, 4};      // value-initialized bases
++
++  }
++
++  namespace test_general_range_based_for_loop
++  {
++
++    struct iter
++    {
++      int i;
++
++      int& operator* ()
++      {
++        return i;
++      }
++
++      const int& operator* () const
++      {
++        return i;
++      }
++
++      iter& operator++()
++      {
++        ++i;
++        return *this;
++      }
++    };
++
++    struct sentinel
++    {
++      int i;
++    };
++
++    bool operator== (const iter& i, const sentinel& s)
++    {
++      return i.i == s.i;
++    }
++
++    bool operator!= (const iter& i, const sentinel& s)
++    {
++      return !(i == s);
++    }
++
++    struct range
++    {
++      iter begin() const
++      {
++        return {0};
++      }
++
++      sentinel end() const
++      {
++        return {5};
++      }
++    };
++
++    void f()
++    {
++      range r {};
++
++      for (auto i : r)
++      {
++        [[maybe_unused]] auto v = i;
++      }
++    }
++
++  }
++
++  namespace test_lambda_capture_asterisk_this_by_value
++  {
++
++    struct t
++    {
++      int i;
++      int foo()
++      {
++        return [*this]()
++        {
++          return i;
++        }();
++      }
++    };
++
++  }
++
++  namespace test_enum_class_construction
++  {
++
++    enum class byte : unsigned char
++    {};
++
++    byte foo {42};
++
++  }
++
++  namespace test_constexpr_if
++  {
++
++    template <bool cond>
++    int f ()
++    {
++      if constexpr(cond)
++      {
++        return 13;
++      }
++      else
++      {
++        return 42;
++      }
++    }
++
++  }
++
++  namespace test_selection_statement_with_initializer
++  {
++
++    int f()
++    {
++      return 13;
++    }
++
++    int f2()
++    {
++      if (auto i = f(); i > 0)
++      {
++        return 3;
++      }
++
++      switch (auto i = f(); i + 4)
++      {
++      case 17:
++        return 2;
++
++      default:
++        return 1;
++      }
++    }
++
++  }
++
++  namespace test_template_argument_deduction_for_class_templates
++  {
++
++    template <typename T1, typename T2>
++    struct pair
++    {
++      pair (T1 p1, T2 p2)
++        : m1 {p1},
++          m2 {p2}
++      {}
++
++      T1 m1;
++      T2 m2;
++    };
++
++    void f()
++    {
++      [[maybe_unused]] auto p = pair{13, 42u};
++    }
++
++  }
++
++  namespace test_non_type_auto_template_parameters
++  {
++
++    template <auto n>
++    struct B
++    {};
++
++    B<5> b1;
++    B<'a'> b2;
++
++  }
++
++  namespace test_structured_bindings
++  {
++
++    int arr[2] = { 1, 2 };
++    std::pair<int, int> pr = { 1, 2 };
++
++    auto f1() -> int(&)[2]
++    {
++      return arr;
++    }
++
++    auto f2() -> std::pair<int, int>&
++    {
++      return pr;
++    }
++
++    struct S
++    {
++      int x1 : 2;
++      volatile double y1;
++    };
++
++    S f3()
++    {
++      return {};
++    }
++
++    auto [ x1, y1 ] = f1();
++    auto& [ xr1, yr1 ] = f1();
++    auto [ x2, y2 ] = f2();
++    auto& [ xr2, yr2 ] = f2();
++    const auto [ x3, y3 ] = f3();
++
++  }
++
++  namespace test_exception_spec_type_system
++  {
++
++    struct Good {};
++    struct Bad {};
++
++    void g1() noexcept;
++    void g2();
++
++    template<typename T>
++    Bad
++    f(T*, T*);
++
++    template<typename T1, typename T2>
++    Good
++    f(T1*, T2*);
++
++    static_assert (std::is_same_v<Good, decltype(f(g1, g2))>);
++
++  }
++
++  namespace test_inline_variables
++  {
++
++    template<class T> void f(T)
++    {}
++
++    template<class T> inline T g(T)
++    {
++      return T{};
++    }
++
++    template<> inline void f<>(int)
++    {}
++
++    template<> int g<>(int)
++    {
++      return 5;
++    }
++
++  }
++
++}  // namespace cxx17
++
++#endif  // __cplusplus < 201703L
++
++]])
+diff --git a/configure.ac b/configure.ac
+index cd678f1..3d50641 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -5,6 +5,7 @@ AC_INIT([polkit], [0.116], [http://lists.freedesktop.org/mailman/listinfo/polkit
+ AM_INIT_AUTOMAKE([])
+ AC_CONFIG_HEADERS(config.h)
+ AC_CONFIG_MACRO_DIR([buildutil])
++m4_include([buildutil/ax_cxx_compile_stdcxx.m4])
+ AM_MAINTAINER_MODE
+ 
+ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+@@ -33,7 +34,7 @@ AC_PROG_LN_S
+ AC_SYS_LARGEFILE
+ AM_PROG_CC_C_O
+ AC_PROG_CXX
+-AX_CXX_COMPILE_STDCXX_11()
++AX_CXX_COMPILE_STDCXX([14], [], [mandatory])
+ 
+ # Taken from dbus
+ AC_ARG_ENABLE(ansi,             [  --enable-ansi           enable -ansi -pedantic gcc flags],enable_ansi=$enableval,enable_ansi=no)
+-- 
+2.24.1
+
+

--- a/sys-auth/polkit/polkit-0.116-r2.ebuild
+++ b/sys-auth/polkit/polkit-0.116-r2.ebuild
@@ -1,0 +1,138 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools pam pax-utils systemd xdg-utils
+
+DESCRIPTION="Policy framework for controlling privileges for system-wide services"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/polkit https://gitlab.freedesktop.org/polkit/polkit"
+SRC_URI="https://www.freedesktop.org/software/${PN}/releases/${P}.tar.gz"
+
+LICENSE="LGPL-2"
+SLOT="0"
+#KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 x86"
+IUSE="consolekit elogind examples gtk +introspection jit kde nls pam selinux systemd test"
+RESTRICT="!test? ( test )"
+
+REQUIRED_USE="^^ ( consolekit elogind systemd )"
+
+BDEPEND="
+	acct-user/polkitd
+	app-text/docbook-xml-dtd:4.1.2
+	app-text/docbook-xsl-stylesheets
+	dev-libs/gobject-introspection-common
+	dev-libs/libxslt
+	dev-util/glib-utils
+	dev-util/gtk-doc-am
+	dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig
+	introspection? ( dev-libs/gobject-introspection )
+"
+DEPEND="
+	dev-lang/spidermonkey:68[-debug]
+	dev-libs/glib:2
+	dev-libs/expat
+	elogind? ( sys-auth/elogind )
+	pam? (
+		sys-auth/pambase
+		sys-libs/pam
+	)
+	systemd? ( sys-apps/systemd:0=[policykit] )
+"
+RDEPEND="${DEPEND}
+	acct-user/polkitd
+	selinux? ( sec-policy/selinux-policykit )
+"
+PDEPEND="
+	consolekit? ( sys-auth/consolekit[policykit] )
+	gtk? ( || (
+		>=gnome-extra/polkit-gnome-0.105
+		>=lxde-base/lxsession-0.5.2
+	) )
+	kde? ( kde-plasma/polkit-kde-agent )
+"
+
+DOCS=( docs/TODO HACKING NEWS README )
+
+PATCHES=(
+	# bug 660880
+	"${FILESDIR}"/polkit-0.115-elogind.patch
+
+	# upstream patch from https://gitlab.freedesktop.org/polkit/polkit/-/merge_requests/48
+	"${FILESDIR}"/polkit-0.116-spidermonkey-68.patch
+
+	# locally rebased patch	
+	"${FILESDIR}"/polkit-0.116-make-netgroup-support-optional-2.patch
+)
+
+QA_MULTILIB_PATHS="
+	usr/lib/polkit-1/polkit-agent-helper-1
+	usr/lib/polkit-1/polkitd"
+
+src_prepare() {
+	default
+
+	sed -i -e 's|unix-group:wheel|unix-user:0|' src/polkitbackend/*-default.rules || die #401513
+
+	# Workaround upstream hack around standard gtk-doc behavior, bug #552170
+	sed -i -e 's/@ENABLE_GTK_DOC_TRUE@\(TARGET_DIR\)/\1/' \
+		-e '/install-data-local:/,/uninstall-local:/ s/@ENABLE_GTK_DOC_TRUE@//' \
+		-e 's/@ENABLE_GTK_DOC_FALSE@install-data-local://' \
+		docs/polkit/Makefile.in || die
+
+	# disable broken test - bug #624022
+	sed -i -e "/^SUBDIRS/s/polkitbackend//" test/Makefile.am || die
+
+	# Fix cross-building, bug #590764, elogind patch, bug #598615
+	eautoreconf
+}
+
+src_configure() {
+	xdg_environment_reset
+
+	local myeconfargs=(
+		--localstatedir="${EPREFIX}"/var
+		--disable-static
+		--enable-man-pages
+		--disable-gtk-doc
+		--disable-examples
+		$(use_enable elogind libelogind)
+		$(use_enable introspection)
+		$(use_enable nls)
+		$(usex pam "--with-pam-module-dir=$(getpam_mod_dir)" '')
+		--with-authfw=$(usex pam pam shadow)
+		$(use_enable systemd libsystemd-login)
+		--with-systemdsystemunitdir="$(systemd_get_systemunitdir)"
+		$(use_enable test)
+		--with-os-type=gentoo
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_compile() {
+	default
+
+	# Required for polkitd on hardened/PaX due to spidermonkey's JIT
+	pax-mark mr src/polkitbackend/.libs/polkitd test/polkitbackend/.libs/polkitbackendjsauthoritytest
+}
+
+src_install() {
+	default
+
+	if use examples; then
+		insinto /usr/share/doc/${PF}/examples
+		doins src/examples/{*.c,*.policy*}
+	fi
+
+	diropts -m 0700 -o polkitd
+	keepdir /usr/share/polkit-1/rules.d
+
+	find "${ED}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	chmod 0700 "${EROOT}"/{etc,usr/share}/polkit-1/rules.d
+	chown polkitd "${EROOT}"/{etc,usr/share}/polkit-1/rules.d
+}


### PR DESCRIPTION
the mozjs patch is from upstream: https://gitlab.freedesktop.org/polkit/polkit/-/merge_requests/48

the netgroup patch does collide with it, so I backported it on my own and renamed it. It did pass all tests on armv7-musl, still I dropped keywords to allow testing for others.

I just noticed that the pullrequest 48 had been updated after I initially downloaded the patch, so please allow me a few days to get back in touch with the rpi and runtime test again with the refreshed patch. 