### PR TITLE
fixes: error: unknown type name 'uint8_t'

### DIFF
--- a/sys-boot/syslinux/files/syslinux-musl.patch
+++ b/sys-boot/syslinux/files/syslinux-musl.patch
@@ -1,9 +1,10 @@
 --- syslinux-6.04-pre1/efi/wrapper.h.orig	2018-05-28 09:29:03.313673979 +0000
 +++ syslinux-6.04-pre1/efi/wrapper.h	2018-05-28 09:22:27.546908344 +0000
-@@ -26,6 +26,19 @@
+@@ -26,6 +26,20 @@
  #define __packed	__attribute__((packed))
  #define OFFSETOF(t,m)	((size_t)&((t *)0)->m)
  
++#include <stdint.h>
 +#ifndef __uint8_t
 +#define __uint8_t uint8_t
 +#endif


### PR DESCRIPTION
Here is the patch to fix following errors.

In file included from /var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.c:25:
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:30:19: error: unknown type name 'uint8_t'
   30 | #define __uint8_t uint8_t
      |                   ^~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:44:2: note: in expansion of macro '__uint8_t'
   44 |  __uint8_t _pad1[0x16];
      |  ^~~~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:30:19: error: unknown type name 'uint8_t'
   30 | #define __uint8_t uint8_t
      |                   ^~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:46:2: note: in expansion of macro '__uint8_t'
   46 |  __uint8_t __pad2[0x3c - 0x1a];
      |  ^~~~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:30:19: error: unknown type name 'uint8_t'
   30 | #define __uint8_t uint8_t
      |                   ^~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:70:2: note: in expansion of macro '__uint8_t'
   70 |  __uint8_t major_linker_version;
      |  ^~~~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:30:19: error: unknown type name 'uint8_t'
   30 | #define __uint8_t uint8_t
      |                   ^~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:71:2: note: in expansion of macro '__uint8_t'
   71 |  __uint8_t minor_linker_version;
      |  ^~~~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:30:19: error: unknown type name 'uint8_t'
   30 | #define __uint8_t uint8_t
      |                   ^~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:85:2: note: in expansion of macro '__uint8_t'
   85 |  __uint8_t major_linker_version;
      |  ^~~~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:30:19: error: unknown type name 'uint8_t'
   30 | #define __uint8_t uint8_t
      |                   ^~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:86:2: note: in expansion of macro '__uint8_t'
   86 |  __uint8_t minor_linker_version;
      |  ^~~~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:30:19: error: unknown type name 'uint8_t'
   30 | #define __uint8_t uint8_t
      |                   ^~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:165:2: note: in expansion of macro '__uint8_t'
  165 |  __uint8_t name[8];
      |  ^~~~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:30:19: error: unknown type name 'uint8_t'; did you mean 'u_int8_t'?
   30 | #define __uint8_t uint8_t
      |                   ^~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.c:47:26: note: in expansion of macro '__uint8_t'
   47 |     __uint32_t so_memsz, __uint8_t class)
      |                          ^~~~~~~~~
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.c: In function 'main':
/var/tmp/portage/sys-boot/syslinux-6.04_pre1/work/syslinux-6.04-pre1/efi/wrapper.h:30:19: error: unknown type name 'uint8_t'; did you mean 'u_int8_t'?
   30 | #define __uint8_t uint8_t
