### PR TITLE
*/*: Remove obsolete values from PYTHON_COMPAT

### DIFF
--- a/app-emulation/libvirt/libvirt-4.10.0.ebuild
+++ b/app-emulation/libvirt/libvirt-4.10.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{4,5,6,7} )
+PYTHON_COMPAT=( python3_7 )
 
 inherit autotools bash-completion-r1 eutils linux-info python-any-r1 readme.gentoo-r1 systemd user
 

--- a/app-emulation/qemu/qemu-4.2.0-r2.ebuild
+++ b/app-emulation/qemu/qemu-4.2.0-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="7"
 
-PYTHON_COMPAT=( python{3_6,3_7} )
+PYTHON_COMPAT=( python3_7 )
 PYTHON_REQ_USE="ncurses,readline"
 
 PLOCALES="bg de_DE fr_FR hu it tr zh_CN"

--- a/app-office/libreoffice/libreoffice-6.4.7.2.ebuild
+++ b/app-office/libreoffice/libreoffice-6.4.7.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 PYTHON_REQ_USE="threads(+),xml"
 
 MY_PV="${PV/_alpha/.alpha}"

--- a/dev-lang/rust/rust-1.34.2.ebuild
+++ b/dev-lang/rust/rust-1.34.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_{5,6,7}} )
+PYTHON_COMPAT=( python{2_7,3_7} )
 
 inherit check-reqs eapi7-ver flag-o-matic llvm multiprocessing python-any-r1 toolchain-funcs
 

--- a/dev-libs/glib/glib-2.62.6.ebuild
+++ b/dev-libs/glib/glib-2.62.6.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python{3_6,3_7} )
+PYTHON_COMPAT=( python3_7 )
 
 inherit flag-o-matic gnome.org gnome2-utils linux-info meson multilib multilib-minimal python-any-r1 toolchain-funcs xdg
 

--- a/dev-libs/glib/glib-2.64.5.ebuild
+++ b/dev-libs/glib/glib-2.64.5.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{7,8} )
 
 inherit flag-o-matic gnome.org gnome2-utils linux-info meson multilib multilib-minimal python-any-r1 toolchain-funcs xdg
 

--- a/dev-util/dwarves/dwarves-1.17.ebuild
+++ b/dev-util/dwarves/dwarves-1.17.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{7,8} )
 inherit multilib cmake-utils python-single-r1
 
 DESCRIPTION="pahole (Poke-a-Hole) and other DWARF2 utilities"

--- a/media-libs/mesa/mesa-20.1.10.ebuild
+++ b/media-libs/mesa/mesa-20.1.10.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{7..9} )
 
 inherit llvm meson multilib-minimal python-any-r1 linux-info
 

--- a/media-tv/kodi/kodi-19.0.ebuild
+++ b/media-tv/kodi/kodi-19.0.ebuild
@@ -10,7 +10,7 @@ LIBDVDNAV_VERSION="6.0.0-Leia-Alpha-3"
 FFMPEG_VERSION="4.3.1"
 CODENAME="Matrix"
 FFMPEG_KODI_VERSION="Beta1"
-PYTHON_COMPAT=( python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 SRC_URI="https://github.com/xbmc/libdvdcss/archive/${LIBDVDCSS_VERSION}.tar.gz -> libdvdcss-${LIBDVDCSS_VERSION}.tar.gz
 	https://github.com/xbmc/libdvdread/archive/${LIBDVDREAD_VERSION}.tar.gz -> libdvdread-${LIBDVDREAD_VERSION}.tar.gz
 	https://github.com/xbmc/libdvdnav/archive/${LIBDVDNAV_VERSION}.tar.gz -> libdvdnav-${LIBDVDNAV_VERSION}.tar.gz

--- a/net-fs/samba/samba-4.11.6-r2.ebuild
+++ b/net-fs/samba/samba-4.11.6-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{7,8} )
 PYTHON_REQ_USE='threads(+),xml(+)'
 inherit python-single-r1 waf-utils multilib-minimal linux-info systemd pam
 

--- a/net-fs/samba/samba-4.11.8.ebuild
+++ b/net-fs/samba/samba-4.11.8.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{7,8} )
 PYTHON_REQ_USE='threads(+),xml(+)'
 inherit python-single-r1 waf-utils multilib-minimal linux-info systemd pam
 

--- a/net-misc/networkmanager/networkmanager-1.26.4.ebuild
+++ b/net-misc/networkmanager/networkmanager-1.26.4.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 GNOME_ORG_MODULE="NetworkManager"
 GNOME2_LA_PUNT="yes"
 VALA_USE_DEPEND="vapigen"
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{7,8} )
 
 inherit bash-completion-r1 gnome2 linux-info multilib python-any-r1 systemd readme.gentoo-r1 vala virtualx udev multilib-minimal
 

--- a/net-misc/rsync/rsync-3.2.0-r1.ebuild
+++ b/net-misc/rsync/rsync-3.2.0-r1.ebuild
@@ -8,7 +8,7 @@ inherit autotools flag-o-matic prefix systemd
 DESCRIPTION="File transfer program to keep remote files into sync"
 HOMEPAGE="https://rsync.samba.org/"
 if [[ "${PV}" == *9999 ]] ; then
-	PYTHON_COMPAT=( python3_{6,7,8} )
+	PYTHON_COMPAT=( python3_{7,8} )
 	inherit git-r3 python-any-r1
 	EGIT_REPO_URI="https://github.com/WayneD/rsync.git"
 else

--- a/sys-apps/policycoreutils/policycoreutils-3.1-r1.ebuild
+++ b/sys-apps/policycoreutils/policycoreutils-3.1-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
-PYTHON_COMPAT=( python{3_6,3_7,3_8} )
+PYTHON_COMPAT=( python{3_7,3_8} )
 PYTHON_REQ_USE="xml"
 
 inherit multilib python-r1 toolchain-funcs bash-completion-r1

--- a/sys-devel/lld/lld-10.0.1.ebuild
+++ b/sys-devel/lld/lld-10.0.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{7..9} )
 inherit cmake flag-o-matic llvm llvm.org python-any-r1
 
 DESCRIPTION="The LLVM linker (link editor)"

--- a/sys-devel/lld/lld-11.0.0.ebuild
+++ b/sys-devel/lld/lld-11.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{7..9} )
 inherit cmake llvm llvm.org python-any-r1
 
 DESCRIPTION="The LLVM linker (link editor)"

--- a/sys-devel/lld/lld-9.0.1.ebuild
+++ b/sys-devel/lld/lld-9.0.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_7 )
 inherit cmake-utils flag-o-matic llvm llvm.org multiprocessing python-any-r1
 
 DESCRIPTION="The LLVM linker (link editor)"

--- a/sys-libs/tevent/tevent-0.10.2.ebuild
+++ b/sys-libs/tevent/tevent-0.10.2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{7,8} )
 PYTHON_REQ_USE="threads(+)"
 
 inherit waf-utils multilib-minimal python-single-r1


### PR DESCRIPTION
This PR follows a similar commit from `::gentoo`. It removes all python3 versions older than python3_7 from `PYTHON_COMPAT`.