### PR TITLE
sys-boot/syslinux: sync with ::gentoo

### DIFF
--- a/sys-boot/syslinux/files/syslinux-6.04_pre1-fcommon.patch
+++ b/sys-boot/syslinux/files/syslinux-6.04_pre1-fcommon.patch
@@ -1,0 +1,54 @@
+https://bugs.gentoo.org/705730
+
+gcc-10 enabled f-no-common by default. Broke syslinux linking.
+--- a/mk/com32.mk
++++ b/mk/com32.mk
+@@ -47,6 +47,7 @@ GCCOPT += $(call gcc_ok,-falign-functions=0,-malign-functions=0)
+ GCCOPT += $(call gcc_ok,-falign-jumps=0,-malign-jumps=0)
+ GCCOPT += $(call gcc_ok,-falign-labels=0,-malign-labels=0)
+ GCCOPT += $(call gcc_ok,-falign-loops=0,-malign-loops=0)
++GCCOPT += $(call gcc_ok,-fcommon)
+ 
+ ifeq ($(FWCLASS),EFI)
+ GCCOPT += -mno-red-zone
+--- a/mk/elf.mk
++++ b/mk/elf.mk
+@@ -42,6 +42,7 @@ GCCOPT += $(call gcc_ok,-falign-functions=0,-malign-functions=0)
+ GCCOPT += $(call gcc_ok,-falign-jumps=0,-malign-jumps=0)
+ GCCOPT += $(call gcc_ok,-falign-labels=0,-malign-labels=0)
+ GCCOPT += $(call gcc_ok,-falign-loops=0,-malign-loops=0)
++GCCOPT += $(call gcc_ok,-fcommon)
+ 
+ com32 = $(topdir)/com32
+ core = $(topdir)/core
+--- a/mk/embedded.mk
++++ b/mk/embedded.mk
+@@ -51,6 +51,7 @@ GCCOPT    += $(call gcc_ok,-falign-jumps=0,-malign-jumps=0)
+ GCCOPT    += $(call gcc_ok,-falign-labels=0,-malign-labels=0)
+ GCCOPT    += $(call gcc_ok,-falign-loops=0,-malign-loops=0)
+ GCCOPT    += $(call gcc_ok,-fvisibility=hidden)
++GCCOPT    += $(call gcc_ok,-fcommon)
+ 
+ LIBGCC    := $(shell $(CC) $(GCCOPT) --print-libgcc)
+ 
+--- a/mk/lib.mk
++++ b/mk/lib.mk
+@@ -28,6 +28,7 @@ GCCOPT += $(call gcc_ok,-falign-functions=0,-malign-functions=0)
+ GCCOPT += $(call gcc_ok,-falign-jumps=0,-malign-jumps=0)
+ GCCOPT += $(call gcc_ok,-falign-labels=0,-malign-labels=0)
+ GCCOPT += $(call gcc_ok,-falign-loops=0,-malign-loops=0)
++GCCOPT += $(call gcc_ok,-fcommon)
+ 
+ INCLUDE	= -I$(SRC)
+ STRIP	= strip --strip-all -R .comment -R .note
+--- a/mk/efi.mk
++++ b/mk/efi.mk
+@@ -7,7 +7,7 @@ core = $(topdir)/core
+ # Set up architecture specifics; for cross compilation, set ARCH as apt
+ # gnuefi sets up architecture specifics in ia32 or x86_64 sub directories
+ # set up the LIBDIR and EFIINC for building for the appropriate architecture
+-GCCOPT := $(call gcc_ok,-fno-stack-protector,)
++GCCOPT := $(call gcc_ok,-fno-stack-protector,) $(call gcc_ok,-fcommon)
+ EFIINC = $(objdir)/include/efi
+ LIBDIR  = $(objdir)/lib
+ 

--- a/sys-boot/syslinux/files/syslinux-6.04_pre1-singleloadsegment.patch
+++ b/sys-boot/syslinux/files/syslinux-6.04_pre1-singleloadsegment.patch
@@ -1,0 +1,304 @@
+Author: Lukas Schwaighofer <lukas@schwaighofer.name>
+Description: Force the linker to put all sections into a single PT_LOAD
+ segment. This is required when using binutils >= 2.31 which writes two PT_LOAD
+ segments by default. This is not supported by the wrapper.c script used to
+ convert the shared object into an elf binary.
+Forwarded: https://www.syslinux.org/archives/2018-August/026167.html
+
+---
+ efi/i386/syslinux.ld   | 37 +++++++++++++++++++++----------------
+ efi/x86_64/syslinux.ld | 37 +++++++++++++++++++++----------------
+ 2 files changed, 42 insertions(+), 32 deletions(-)
+
+diff --git a/efi/i386/syslinux.ld b/efi/i386/syslinux.ld
+index bab3fc7..5b4589d 100644
+--- a/efi/i386/syslinux.ld
++++ b/efi/i386/syslinux.ld
+@@ -19,6 +19,11 @@ OUTPUT_FORMAT("elf32-i386", "elf32-i386", "elf32-i386")
+ OUTPUT_ARCH(i386)
+ ENTRY(_start)
+ 
++PHDRS
++{
++	all PT_LOAD ;
++}
++
+ SECTIONS
+ {
+ 	. = 0;
+@@ -31,7 +36,7 @@ SECTIONS
+ 		*(.text)
+ 		*(.text.*)
+ 		__text_end = .;
+-	}
++	} :all
+ 
+ 	. = ALIGN(16);
+ 
+@@ -40,7 +45,7 @@ SECTIONS
+ 		*(.rodata)
+ 		*(.rodata.*)
+ 		__rodata_end = .;
+-	}
++	} :all
+ 
+ 	. = ALIGN(4);
+ 
+@@ -49,14 +54,14 @@ SECTIONS
+ 		KEEP (*(SORT(.ctors.*)))
+ 		KEEP (*(.ctors))
+ 		__ctors_end = .;
+-	}
++	} :all
+ 
+ 	.dtors : {
+ 		__dtors_start = .;
+ 		KEEP (*(SORT(.dtors.*)))
+ 		KEEP (*(.dtors))
+ 		__dtors_end = .;
+-	}
++	} :all
+ 
+ 	. = ALIGN(4096);
+ 	.rel : {
+@@ -64,7 +69,7 @@ SECTIONS
+ 		*(.rel.data)
+ 		*(.rel.data.*)
+ 		*(.rel.ctors)
+-	}
++	} :all
+ 
+ 	. = ALIGN(4);
+ 
+@@ -72,14 +77,14 @@ SECTIONS
+ 		__gnu_hash_start = .;
+ 		*(.gnu.hash)
+ 		__gnu_hash_end = .;
+-	}
++	} :all
+ 
+ 
+ 	.dynsym : {
+ 		__dynsym_start = .;
+ 		*(.dynsym)
+ 		__dynsym_end = .;
+-	}
++	} :all
+ 
+ 	. = ALIGN(4);
+ 
+@@ -87,7 +92,7 @@ SECTIONS
+ 		__dynstr_start = .;
+ 		*(.dynstr)
+ 		__dynstr_end = .;
+-	}
++	} :all
+ 
+ 	. = ALIGN(4);
+ 
+@@ -104,7 +109,7 @@ SECTIONS
+ 		KEEP (*(.got.plt))
+ 		KEEP (*(.got))
+ 		__got_end = .;
+-	}
++	} :all
+ 
+ 	. = ALIGN(4);
+ 
+@@ -112,7 +117,7 @@ SECTIONS
+ 		__dynamic_start = .;
+ 		*(.dynamic)
+ 		__dynamic_end = .;
+-	}
++	} :all
+ 
+ 	. = ALIGN(16);
+ 
+@@ -122,19 +127,19 @@ SECTIONS
+ 		*(.data.*)
+ 		*(.lowmem)
+ 		__data_end = .;
+-	}
++	} :all
+ 
+ 	.reloc : {
+ 		*(.reloc)
+-	}
++	} :all
+ 
+ 	.symtab : {
+ 		*(.symtab)
+-	}
++	} :all
+ 
+ 	.strtab : {
+ 		*(.strtab)
+-	}
++	} :all
+ 
+ 	.bss (NOLOAD) : {
+ 		/* the EFI loader doesn't seem to like a .bss section,
+@@ -148,7 +153,7 @@ SECTIONS
+ 		__bss_end = .;
+ 		*(.sbss)
+ 		*(.scommon)
+-	}
++	} :all
+ 	__bss_len = ABSOLUTE(__bss_end) - ABSOLUTE(__bss_start);
+ 	__bss_dwords = (__bss_len + 3) >> 2;
+ 
+@@ -161,7 +166,7 @@ SECTIONS
+ 		*(.hugebss)
+ 		*(.hugebss.*)
+ 		__hugebss_end = .;
+-	}
++	} :all
+ 
+ 	_end = .;
+ 
+diff --git a/efi/x86_64/syslinux.ld b/efi/x86_64/syslinux.ld
+index 450641c..cad28a8 100644
+--- a/efi/x86_64/syslinux.ld
++++ b/efi/x86_64/syslinux.ld
+@@ -19,6 +19,11 @@ OUTPUT_FORMAT("elf64-x86-64", "elf64-x86-64", "elf64-x86-64")
+ OUTPUT_ARCH(i386:x86-64)
+ ENTRY(_start)
+ 
++PHDRS
++{
++	all PT_LOAD ;
++}
++
+ SECTIONS
+ {
+ 	. = 0;
+@@ -31,7 +36,7 @@ SECTIONS
+ 		*(.text)
+ 		*(.text.*)
+ 		__text_end = .;
+-	}
++	} :all
+ 
+ 	. = ALIGN(16);
+ 
+@@ -40,7 +45,7 @@ SECTIONS
+ 		*(.rodata)
+ 		*(.rodata.*)
+ 		__rodata_end = .;
+-	}
++	} :all
+ 
+ 	. = ALIGN(4);
+ 
+@@ -49,14 +54,14 @@ SECTIONS
+ 		KEEP (*(SORT(.ctors.*)))
+ 		KEEP (*(.ctors))
+ 		__ctors_end = .;
+-	}
++	} :all
+ 
+ 	.dtors : {
+ 		__dtors_start = .;
+ 		KEEP (*(SORT(.dtors.*)))
+ 		KEEP (*(.dtors))
+ 		__dtors_end = .;
+-	}
++	} :all
+ 
+ 	. = ALIGN(4096);
+ 	.rel : {
+@@ -64,7 +69,7 @@ SECTIONS
+ 		*(.rel.data)
+ 		*(.rel.data.*)
+ 		*(.rel.ctors)
+-	}
++	} :all
+ 
+ 	. = ALIGN(4);
+ 
+@@ -72,14 +77,14 @@ SECTIONS
+ 		__gnu_hash_start = .;
+ 		*(.gnu.hash)
+ 		__gnu_hash_end = .;
+-	}
++	} :all
+ 
+ 
+ 	.dynsym : {
+ 		__dynsym_start = .;
+ 		*(.dynsym)
+ 		__dynsym_end = .;
+-	}
++	} :all
+ 
+ 	. = ALIGN(4);
+ 
+@@ -87,7 +92,7 @@ SECTIONS
+ 		__dynstr_start = .;
+ 		*(.dynstr)
+ 		__dynstr_end = .;
+-	}
++	} :all
+ 
+ 	. = ALIGN(4);
+ 
+@@ -104,7 +109,7 @@ SECTIONS
+ 		KEEP (*(.got.plt))
+ 		KEEP (*(.got))
+ 		__got_end = .;
+-	}
++	} :all
+ 
+ 	. = ALIGN(4);
+ 
+@@ -112,7 +117,7 @@ SECTIONS
+ 		__dynamic_start = .;
+ 		*(.dynamic)
+ 		__dynamic_end = .;
+-	}
++	} :all
+ 
+ 	. = ALIGN(16);
+ 
+@@ -122,19 +127,19 @@ SECTIONS
+ 		*(.data.*)
+ 		*(.lowmem)
+ 		__data_end = .;
+-	}
++	} :all
+ 
+ 	.reloc : {
+ 		*(.reloc)
+-	}
++	} :all
+ 
+ 	.symtab : {
+ 		*(.symtab)
+-	}
++	} :all
+ 
+ 	.strtab : {
+ 		*(.strtab)
+-	}
++	} :all
+ 
+ 	.bss (NOLOAD) : {
+ 		/* the EFI loader doesn't seem to like a .bss section,
+@@ -148,7 +153,7 @@ SECTIONS
+ 		__bss_end = .;
+ 		*(.sbss)
+ 		*(.scommon)
+-	}
++	} :all
+ 	__bss_len = ABSOLUTE(__bss_end) - ABSOLUTE(__bss_start);
+ 	__bss_dwords = (__bss_len + 3) >> 2;
+ 
+@@ -161,7 +166,7 @@ SECTIONS
+ 		*(.hugebss)
+ 		*(.hugebss.*)
+ 		__hugebss_end = .;
+-	}
++	} :all
+ 
+ 	_end = .;
+ 

--- a/sys-boot/syslinux/metadata.xml
+++ b/sys-boot/syslinux/metadata.xml
@@ -8,4 +8,7 @@
 	<email>base-system@gentoo.org</email>
 	<name>Gentoo Base System</name>
 </maintainer>
+<upstream>
+	<remote-id type="cpe">cpe:/a:gentoo:syslinux</remote-id>
+</upstream>
 </pkgmetadata>


### PR DESCRIPTION
sync sys-boot/syslinux with ::gentoo. EAPI=7 etc now, but patch still required.

Tested on ~amd64.