### PR TITLE
Sync stable keywords with ::gentoo.

### DIFF
--- a/sys-devel/gcc/gcc-10.2.0-r5.ebuild
+++ b/sys-devel/gcc/gcc-10.2.0-r5.ebuild
@@ -7,7 +7,7 @@ PATCH_VER="6"
 
 inherit toolchain
 
-KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 x86"
 
 RDEPEND=""
 BDEPEND="${CATEGORY}/binutils"


### PR DESCRIPTION
Currently ::gentoo is "ahead" of us, so upgrading gcc will get the wrong one.