### PR TITLE
sys-devel/gcc: Sync 11.2.0 stable keywords with ::gentoo.

### DIFF
--- a/sys-devel/gcc/gcc-11.2.0.ebuild
+++ b/sys-devel/gcc/gcc-11.2.0.ebuild
@@ -7,7 +7,7 @@ PATCH_VER="1"
 
 inherit toolchain
 
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 
 RDEPEND=""
 BDEPEND="${CATEGORY}/binutils"


### PR DESCRIPTION
Signed-off-by: Dave Flogeras <dflogeras2@gmail.com>