### PR TITLE
sys-auth/polkit: fix build with -duktape

### DIFF
--- a/sys-auth/polkit/polkit-0.120-r1.ebuild
+++ b/sys-auth/polkit/polkit-0.120-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -88,6 +88,7 @@ src_configure() {
 		$(meson_use introspection)
 		$(meson_use test tests)
 		$(usex pam "-Dpam_module_dir=$(getpam_mod_dir)" '')
+		-Djs_engine="$(usex duktape duktape mozjs)"
 	)
 	meson_src_configure
 }


### PR DESCRIPTION
correctly set `-Djs_engine` when the duktape useflag is or is not set

Closes: https://github.com/gentoo/musl/issues/458
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: yemou Hannam <yemou@protonmail.com>