### PR TITLE
dev-lang/rust: remove arm keywords

### DIFF
--- a/dev-lang/rust/rust-1.60.0.ebuild
+++ b/dev-lang/rust/rust-1.60.0.ebuild
@@ -19,7 +19,7 @@ else
 	SLOT="stable/${ABI_VER}"
 	MY_P="rustc-${PV}"
 	SRC="${MY_P}-src.tar.xz"
-	KEYWORDS="amd64 ~arm arm64 ppc64 x86"
+	KEYWORDS="amd64 arm64 ppc64 x86"
 fi
 
 RUST_STAGE0_VERSION="1.$(($(ver_cut 2) - 1)).0"

--- a/dev-lang/rust/rust-1.62.1.ebuild
+++ b/dev-lang/rust/rust-1.62.1.ebuild
@@ -19,7 +19,7 @@ else
 	SLOT="stable/${ABI_VER}"
 	MY_P="rustc-${PV}"
 	SRC="${MY_P}-src.tar.xz"
-	KEYWORDS="amd64 arm arm64 ppc64 ~x86"
+	KEYWORDS="amd64 arm64 ppc64 ~x86"
 fi
 
 RUST_STAGE0_VERSION="1.$(($(ver_cut 2) - 1)).0"


### PR DESCRIPTION
not going to work, unless there's a musl-based stage: 

```
>>> Compiling source in /var/tmp/portage/dev-lang/rust-1.62.1/work/rustc-1.62.1-src ...
Building rustbuild
running: /var/tmp/portage/dev-lang/rust-1.62.1/work/rust-stage0/bin/cargo build --manifest-path /var/tmp/portage/dev-lang/rust-1.62.1/work/rustc-1.62.1-src/src/bootstrap/Cargo.toml --verbose --verbose --locked --frozen
Traceback (most recent call last):
  File "/var/tmp/portage/dev-lang/rust-1.62.1/work/rustc-1.62.1-src/./x.py", line 27, in <module>
    bootstrap.main()
  File "/var/tmp/portage/dev-lang/rust-1.62.1/work/rustc-1.62.1-src/src/bootstrap/bootstrap.py", line 1195, in main
    bootstrap(help_triggered)
  File "/var/tmp/portage/dev-lang/rust-1.62.1/work/rustc-1.62.1-src/src/bootstrap/bootstrap.py", line 1169, in bootstrap
    build.build_bootstrap()
  File "/var/tmp/portage/dev-lang/rust-1.62.1/work/rustc-1.62.1-src/src/bootstrap/bootstrap.py", line 899, in build_bootstrap
    run(args, env=env, verbose=self.verbose)
  File "/var/tmp/portage/dev-lang/rust-1.62.1/work/rustc-1.62.1-src/src/bootstrap/bootstrap.py", line 183, in run
    ret = subprocess.Popen(args, **kwargs)
  File "/usr/lib/python3.10/subprocess.py", line 969, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.10/subprocess.py", line 1845, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/var/tmp/portage/dev-lang/rust-1.62.1/work/rust-stage0/bin/cargo'
```

```
file  /var/tmp/portage/dev-lang/rust-1.62.1/work/rust-stage0/bin/cargo
/var/tmp/portage/dev-lang/rust-1.62.1/work/rust-stage0/bin/cargo: ELF 32-bit LSB pie executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.101, with debug_info, not stripped
```

full build log if desired: [build.log.gz](https://github.com/gentoo/musl/files/9267940/build.log.gz)